### PR TITLE
fix: stability improvements — 10 reliability fixes for sync engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ scratchpad/*
 .turbo/
 
 # Generated service worker (copied from core package)
-examples/react-filesync/public/file-sync-sw.js
+examples/react-filesync/public/file-sync-sw.js.agents/

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@ scratchpad/*
 .turbo/
 
 # Generated service worker (copied from core package)
-examples/react-filesync/public/file-sync-sw.js.agents/
+examples/react-filesync/public/file-sync-sw.js
+
+# Agent reference repos
+.agents/

--- a/README.md
+++ b/README.md
@@ -233,11 +233,13 @@ See `examples/react-filesync` or `examples/vue-filesync` for complete implementa
 When files sync across clients, the file metadata may arrive before the file content is uploaded. Use `getFileDisplayState()` to determine if a file can be displayed:
 
 ```typescript
-import { getFileDisplayState } from '@livestore-filesync/core'
+import { getFileDisplayState, rowsToLocalFilesState } from '@livestore-filesync/core'
+import { queryDb } from '@livestore/livestore'
 
-// In your component
-const [localFileState] = store.useClientDocument(tables.localFileState)
-const { canDisplay, isUploading } = getFileDisplayState(file, localFileState?.localFiles ?? {})
+// In your React component
+const rows = store.useQuery(queryDb(tables.localFileState.select()))
+const localFilesState = useMemo(() => rowsToLocalFilesState(rows), [rows])
+const { canDisplay, isUploading } = getFileDisplayState(file, localFilesState)
 
 // canDisplay is true when:
 // - The file exists locally (originating client can display immediately)

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ The `@livestore-filesync/image` package provides client-side thumbnail generatio
 import { createFileSyncSchema } from '@livestore-filesync/core/schema'
 import { createThumbnailSchema } from '@livestore-filesync/image/thumbnails/schema'
 import { initThumbnails, resolveThumbnailUrl } from '@livestore-filesync/image/thumbnails'
+import { State } from '@livestore/livestore'
 import { layer as opfsLayer } from '@livestore-filesync/opfs'
 
 // 1. Merge schemas
@@ -370,13 +371,20 @@ const fileSyncSchema = createFileSyncSchema()
 const thumbnailSchema = createThumbnailSchema()
 
 const tables = { ...fileSyncSchema.tables, ...thumbnailSchema.tables }
+const events = { ...fileSyncSchema.events, ...thumbnailSchema.events }
+
+const materializers = State.SQLite.materializers(events, {
+  ...fileSyncSchema.createMaterializers(tables),
+  ...thumbnailSchema.createMaterializers(tables)
+})
 
 // 2. Initialize (after FileSync is initialized)
 const dispose = initThumbnails(store, {
   sizes: { small: 128, medium: 256, large: 512 },
   format: 'webp',
   fileSystem: opfsLayer(),
-  workerUrl: new URL('./thumbnail.worker.ts', import.meta.url)
+  workerUrl: new URL('./thumbnail.worker.ts', import.meta.url),
+  schema: { tables }
 })
 
 // 3. Create your worker file (thumbnail.worker.ts)

--- a/README.md
+++ b/README.md
@@ -233,13 +233,14 @@ See `examples/react-filesync` or `examples/vue-filesync` for complete implementa
 When files sync across clients, the file metadata may arrive before the file content is uploaded. Use `getFileDisplayState()` to determine if a file can be displayed:
 
 ```typescript
-import { getFileDisplayState, rowsToLocalFilesState } from '@livestore-filesync/core'
+import { getFileDisplayState } from '@livestore-filesync/core'
 import { queryDb } from '@livestore/livestore'
 
-// In your React component
-const rows = store.useQuery(queryDb(tables.localFileState.select()))
-const localFilesState = useMemo(() => rowsToLocalFilesState(rows), [rows])
-const { canDisplay, isUploading } = getFileDisplayState(file, localFilesState)
+// In your React component — query only this file's local state for targeted reactivity
+const localFileState = store.useQuery(
+  queryDb(tables.localFileState.where({ fileId: file.id }).first())
+)
+const { canDisplay, isUploading } = getFileDisplayState(file, localFileState ?? undefined)
 
 // canDisplay is true when:
 // - The file exists locally (originating client can display immediately)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The services are wired together as Effect layers inside `createFileSync` and the
   directory listing) and metadata handling. Swapping the `FileSystem` layer changes the local
   storage backend without touching higher layers.
 
-- `LocalFileStateManager` (internal): centralized manager for all `localFilesState` mutations. Uses an internal
+- `LocalFileStateManager` (internal): centralized manager for all `localFileState` table mutations. Uses an internal
   lock to ensure atomic read-modify-write operations, preventing race conditions when multiple
   concurrent operations try to update the state. All state changes go through this service.
 
@@ -319,14 +319,18 @@ Files sync via LiveStore, but the file content may not be immediately available:
    they can download and display it
 
 The `files` table contains synced metadata (including `remoteKey`), while `localFileState` is a
-client document tracking what each client has locally.
+client-local SQLite table tracking what each client has locally (one row per file).
 
 ### getFileDisplayState
 
 ```typescript
 import { getFileDisplayState } from '@livestore-filesync/core'
 
-const displayState = getFileDisplayState(file, localFilesState)
+// Query just this file's local state row
+const localFileState = store.useQuery(
+  queryDb(tables.localFileState.where({ fileId: file.id }).first())
+)
+const displayState = getFileDisplayState(file, localFileState ?? undefined)
 
 // displayState contains:
 // - canDisplay: boolean  - true if file is available (local copy OR remote)
@@ -339,13 +343,15 @@ const displayState = getFileDisplayState(file, localFilesState)
 ### UI Pattern
 
 ```tsx
-// React example
-import { getFileDisplayState, rowsToLocalFilesState } from '@livestore-filesync/core'
+// React example — per-file query for targeted reactivity
+import { getFileDisplayState } from '@livestore-filesync/core'
 import { queryDb } from '@livestore/livestore'
 
-const rows = store.useQuery(queryDb(tables.localFileState.select()))
-const localFilesState = useMemo(() => rowsToLocalFilesState(rows), [rows])
-const { canDisplay, isUploading } = getFileDisplayState(file, localFilesState)
+// Query only this file's local state row (not all rows)
+const localFileState = store.useQuery(
+  queryDb(tables.localFileState.where({ fileId: file.id }).first())
+)
+const { canDisplay, isUploading } = getFileDisplayState(file, localFileState ?? undefined)
 
 return canDisplay
   ? <img src={`/${file.path}`} />
@@ -356,6 +362,7 @@ This ensures:
 - Originating client displays immediately (has local copy)
 - Other clients show placeholder until upload completes
 - Correct version is displayed after edits (hash comparison)
+- Each component only re-renders when its own file's state changes (not when any file changes)
 
 ## Multi-Tab Coordination
 
@@ -414,17 +421,19 @@ This ensures:
 
 ## Sync Status
 
-The `getSyncStatus()` utility derives aggregate sync status from the `localFileState` client document.
+The `getSyncStatus()` utility derives aggregate sync status from the `localFileState` table rows.
 Since `localFileState` is reactive via LiveStore, applications can subscribe to it and compute
-sync status on each update.
+sync status on each update. The function accepts rows directly from `useQuery` — no conversion needed.
 
 ### getSyncStatus
 
 ```typescript
 import { getSyncStatus } from '@livestore-filesync/core'
+import { queryDb } from '@livestore/livestore'
 
-// The function takes the localFiles map and returns aggregate status
-const status = getSyncStatus(localFilesState)
+// Pass rows directly from the table query — no map conversion needed
+const rows = store.query(queryDb(tables.localFileState.select()))
+const status = getSyncStatus(rows)
 
 // status contains:
 // - uploadingCount: number     - files currently uploading
@@ -450,13 +459,13 @@ const status = getSyncStatus(localFilesState)
 **React:**
 
 ```tsx
-import { getSyncStatus, rowsToLocalFilesState } from '@livestore-filesync/core'
+import { getSyncStatus } from '@livestore-filesync/core'
 import { queryDb } from '@livestore/livestore'
 
 function SyncIndicator() {
+  // Pass rows directly to getSyncStatus — no map conversion needed
   const rows = store.useQuery(queryDb(tables.localFileState.select()))
-  const localFilesState = useMemo(() => rowsToLocalFilesState(rows), [rows])
-  const status = getSyncStatus(localFilesState)
+  const status = useMemo(() => getSyncStatus(rows), [rows])
 
   if (status.isSyncing) {
     return (
@@ -481,11 +490,12 @@ function SyncIndicator() {
 import { computed } from 'vue'
 import { useQuery } from 'vue-livestore'
 import { queryDb } from '@livestore/livestore'
-import { getSyncStatus, rowsToLocalFilesState } from '@livestore-filesync/core'
+import { getSyncStatus } from '@livestore-filesync/core'
 import { tables } from './schema'
 
+// Pass rows directly — no map conversion needed
 const rows = useQuery(queryDb(tables.localFileState.select()))
-const syncStatus = computed(() => getSyncStatus(rowsToLocalFilesState(rows.value)))
+const syncStatus = computed(() => getSyncStatus(rows.value))
 </script>
 
 <template>
@@ -507,9 +517,9 @@ import { getSyncStatus } from '@livestore-filesync/core'
 import { tables } from './schema'
 
 const unsubscribe = store.subscribe(
-  queryDb(tables.localFileState.get()),
-  (state) => {
-    const status = getSyncStatus(state.localFiles)
+  queryDb(tables.localFileState.select()),
+  (rows) => {
+    const status = getSyncStatus(rows)
     document.getElementById('sync-status').textContent =
       status.isSyncing ? `Syncing ${status.uploadingCount + status.downloadingCount} files...` : 'Synced'
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -746,6 +746,9 @@ onFileSyncEvent((event) => {
     case 'sync:error-retry-start':
       console.log(`Retrying ${event.fileIds.length} files`)
       break
+    case 'transfer:exhausted':
+      console.error(`${event.kind} for ${event.fileId} failed after all retries:`, event.error)
+      break
   }
 })
 ```
@@ -754,12 +757,13 @@ onFileSyncEvent((event) => {
 
 | Event | Fields | Description |
 |-------|--------|-------------|
-| `sync:error` | `error`, `context?` | General sync error (batch processing, bootstrap, etc.) |
+| `sync:error` | `error`, `context?` | General sync error (batch processing, bootstrap, start, etc.) |
 | `sync:stream-error` | `error`, `attempt?` | Event stream error with retry attempt number |
 | `sync:stream-exhausted` | `error`, `attempts` | Max recovery attempts reached |
 | `sync:recovery` | `from` | Successful recovery ("stream-error" or "error-retry") |
 | `sync:error-retry-start` | `fileIds` | Files being retried from error state |
 | `sync:heartbeat-recovery` | `reason` | Heartbeat recovered dead stream or stuck queue |
+| `transfer:exhausted` | `kind`, `fileId`, `error` | Transfer failed after all retries exhausted |
 
 ### Heartbeat Monitoring
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,8 +340,12 @@ const displayState = getFileDisplayState(file, localFilesState)
 
 ```tsx
 // React example
-const [localFileState] = store.useClientDocument(tables.localFileState)
-const { canDisplay, isUploading } = getFileDisplayState(file, localFileState?.localFiles ?? {})
+import { getFileDisplayState, rowsToLocalFilesState } from '@livestore-filesync/core'
+import { queryDb } from '@livestore/livestore'
+
+const rows = store.useQuery(queryDb(tables.localFileState.select()))
+const localFilesState = useMemo(() => rowsToLocalFilesState(rows), [rows])
+const { canDisplay, isUploading } = getFileDisplayState(file, localFilesState)
 
 return canDisplay
   ? <img src={`/${file.path}`} />
@@ -446,11 +450,13 @@ const status = getSyncStatus(localFilesState)
 **React:**
 
 ```tsx
-import { getSyncStatus } from '@livestore-filesync/core'
+import { getSyncStatus, rowsToLocalFilesState } from '@livestore-filesync/core'
+import { queryDb } from '@livestore/livestore'
 
 function SyncIndicator() {
-  const [localFileState] = store.useClientDocument(tables.localFileState)
-  const status = getSyncStatus(localFileState?.localFiles ?? {})
+  const rows = store.useQuery(queryDb(tables.localFileState.select()))
+  const localFilesState = useMemo(() => rowsToLocalFilesState(rows), [rows])
+  const status = getSyncStatus(localFilesState)
 
   if (status.isSyncing) {
     return (
@@ -473,12 +479,13 @@ function SyncIndicator() {
 ```vue
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useClientDocument } from 'vue-livestore'
-import { getSyncStatus } from '@livestore-filesync/core'
+import { useQuery } from 'vue-livestore'
+import { queryDb } from '@livestore/livestore'
+import { getSyncStatus, rowsToLocalFilesState } from '@livestore-filesync/core'
 import { tables } from './schema'
 
-const localFileState = useClientDocument(tables.localFileState)
-const syncStatus = computed(() => getSyncStatus(localFileState.value?.localFiles ?? {}))
+const rows = useQuery(queryDb(tables.localFileState.select()))
+const syncStatus = computed(() => getSyncStatus(rowsToLocalFilesState(rows.value)))
 </script>
 
 <template>

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -161,6 +161,9 @@ pnpm -r publish --access public
 # 8. Push commits and tags
 git push origin main
 git push origin "v$VERSION"
+
+# 9. Create GitHub release
+gh release create "v$VERSION" --title "v$VERSION" --generate-notes --target main
 ```
 
 ### Quick Release Script
@@ -174,7 +177,10 @@ git add . && \
 git commit -m "chore: release $(node -p "require('./packages/core/package.json').version")" && \
 git tag -a "v$(node -p "require('./packages/core/package.json').version")" -m "Release v$(node -p "require('./packages/core/package.json').version")" && \
 pnpm -r publish --access public && \
-git push origin main --tags
+git push origin main --tags && \
+gh release create "v$(node -p "require('./packages/core/package.json').version")" \
+  --title "v$(node -p "require('./packages/core/package.json').version")" \
+  --generate-notes --target main
 ```
 
 ## Troubleshooting

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -205,6 +205,47 @@ const ensureWorkers = (): Effect.Effect<void, never, Scope.Scope> =>
 
 ---
 
+### 5. Stability Improvements (Batch)
+
+**Branch:** `fix/stability-improvements`
+
+A systematic set of 10 stability fixes identified through deep analysis of error handling, sync edge cases, and type safety. Each fix has its own commit with tests.
+
+#### Completed Fixes
+
+1. **Emit callback safety** (`88599b2`): Wrapped each `onEvent` callback invocation in try/catch so one throwing subscriber doesn't crash the sync engine or prevent other subscribers from receiving events.
+
+2. **Effect.tryPromise for preprocessors** (`ba817e5`): Changed `Effect.promise(() => applyPreprocessor(...))` to `Effect.tryPromise` so preprocessor failures produce a typed `StorageError` instead of a fiber-crashing defect.
+
+3. **Atomic enqueue deduplication** (`75f0d56`): Changed non-atomic `Ref.get` + `Ref.update` to `Ref.modify` in `enqueueDownload`/`enqueueUpload`/`prioritizeDownload`, preventing races where two concurrent fibers double-enqueue the same file.
+
+4. **Per-event error handling in batch processing** (`3acaf78`): Previously the entire batch was wrapped in a single try/catch. Now each event is wrapped individually so a failure in event 3 of 5 doesn't replay events 1-2.
+
+5. **goOffline preserves error states** (`5c60b65`): `goOffline()` now only resets `inProgress` transfers to `queued`. Files that failed for non-network reasons (corrupt, too large) are no longer infinitely retried.
+
+6. **Log/emit on retry exhaustion** (`66af9dd`): When all retries are exhausted in `SyncExecutor.processTask`, an `Effect.logWarning` is emitted and the new `onTaskComplete` callback notifies FileSync, which emits a `transfer:exhausted` event.
+
+7. **Interrupt in-flight on leadership loss** (`e061982`): `stopSyncLoop()` now calls `executor.interruptInflight()` to cancel running transfer fibers before they commit conflicting state. Interrupted transfers are reset from `inProgress` to `queued`.
+
+8. **Cancel pending downloads on deleteFile** (`0c69564`): `deleteFile()` now calls `executor.cancelDownload(fileId)` to prevent a queued download from completing after the file is deleted.
+
+9. **Signer response validation** (`7570d31`): Upload/download signer responses are now validated at runtime instead of trusting `as` casts. Invalid responses produce clear error messages.
+
+10. **Emit sync:error on start() failure** (`656213f`): `createFileSync.start()` now emits a `sync:error` event with `context: "start"` when initialization fails, making boot failures visible to event listeners.
+
+#### New Event Type
+
+| Event | Fields | Description |
+|-------|--------|-------------|
+| `transfer:exhausted` | `kind`, `fileId`, `error` | A transfer failed after all retries were exhausted |
+
+#### New SyncExecutor APIs
+
+- `onTaskComplete` callback parameter on `makeSyncExecutor` — called after each task (success or failure)
+- `interruptInflight()` method — interrupts all running transfer fibers, returns metadata about what was interrupted
+
+---
+
 ## Architecture Integration
 
 These stability features integrate with the existing FileSync architecture:
@@ -219,7 +260,17 @@ These stability features integrate with the existing FileSync architecture:
     |                          +-- Stream error recovery (exponential backoff)
     |                          +-- Fiber ref tracking for heartbeat
     |
-    +-- handleEventBatch() ──> updates lastBatchAtRef, lastBatchCursorRef
+    +-- stopSyncLoop() ──> executor.pause() + executor.interruptInflight()
+    |                       + reset inProgress → queued + stopEventStream()
+    |
+    +-- handleEventBatch() ──> per-event error handling, cursor always advances
+    |                          updates lastBatchAtRef, lastBatchCursorRef
+    |
+    +-- deleteFile() ──> executor.cancelDownload() + deleteFileRecord()
+    |
+    +-- goOffline() ──> only resets inProgress (preserves error states)
+    |
+    +-- emit() ──> try/catch per callback (one bad subscriber can't crash sync)
     |
     +-- startHeartbeat() ──> periodic tick (every 15s by default)
                                 |
@@ -233,8 +284,12 @@ These stability features integrate with the existing FileSync architecture:
 [SyncExecutor]
     |
     +-- ensureWorkers() ──> restart dead worker fibers
+    +-- interruptInflight() ──> cancel all running transfer fibers
+    +-- onTaskComplete callback ──> notifies FileSync of success/failure
+    +-- Atomic enqueue deduplication via Ref.modify
     |
     +-- Worker fiber refs ──> downloadWorkerFiberRef, uploadWorkerFiberRef
+    +-- Inflight fiber tracking ──> inflightFibersRef (for interrupt support)
 ```
 
 ## Monitoring
@@ -257,6 +312,9 @@ onFileSyncEvent((event) => {
       break
     case 'sync:recovery':
       console.log(`Recovered from ${event.from}`)
+      break
+    case 'transfer:exhausted':
+      console.error(`${event.kind} for ${event.fileId} failed after all retries:`, event.error)
       break
   }
 })

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -10,7 +10,7 @@ This document describes the stability and self-healing mechanisms implemented in
 
 **Problem:** `recoverStaleTransfers()` was running every time `startEventStream()` was called. Mid-session stream restarts (from `syncNow()`, heartbeat recoveries, etc.) could incorrectly flip legitimate `inProgress` transfers back to `queued`, causing state corruption when `applyFileState()` keeps `queued` even if the file is already in sync.
 
-**Solution:** 
+**Solution:**
 - Added `staleRecoveryDoneRef` boolean to track whether recovery has run
 - Created `maybeRecoverStaleTransfers()` wrapper that checks the flag before running
 - Moved recovery from `startEventStream()` to `startSyncLoop()`
@@ -140,7 +140,7 @@ const ensureWorkers = (): Effect.Effect<void, never, Scope.Scope> =>
 
 ### Task 1: Stale Transfer Recovery Gating
 
-**File:** `tasks/01_stability_stale-recovery-gating.md`  
+**File:** `tasks/01_stability_stale-recovery-gating.md`
 **Status:** DONE
 
 **Goal:** Avoid resetting legitimate `inProgress` transfers to `queued` during mid-session stream restarts while preserving safety on cold start.
@@ -160,7 +160,7 @@ const ensureWorkers = (): Effect.Effect<void, never, Scope.Scope> =>
 
 ### Task 2: Executor Worker Liveness
 
-**File:** `tasks/02_stability_executor-worker-liveness.md`  
+**File:** `tasks/02_stability_executor-worker-liveness.md`
 **Status:** DONE (implemented as part of heartbeat v1)
 
 **Goal:** Ensure download/upload workers cannot silently die and leave the queue stuck. Provide a way to re-create workers when the executor is resumed or when heartbeat detects a stuck queue.
@@ -180,7 +180,7 @@ const ensureWorkers = (): Effect.Effect<void, never, Scope.Scope> =>
 
 ### Task 3: Stream Stall Watchdog
 
-**File:** `tasks/03_stability_stream-stall-watchdog.md`  
+**File:** `tasks/03_stability_stream-stall-watchdog.md`
 **Status:** DONE
 
 **Goal:** Detect when the event stream is alive but no longer advancing while upstream head moves, and restart the stream automatically to recover from a stalled cursor.

--- a/examples/node-filesync/package.json
+++ b/examples/node-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-node-example",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/examples/node-filesync/package.json
+++ b/examples/node-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-node-example",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/examples/node-filesync/package.json
+++ b/examples/node-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-node-example",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/examples/react-filesync/package.json
+++ b/examples/react-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-example",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-filesync/package.json
+++ b/examples/react-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-example",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-filesync/package.json
+++ b/examples/react-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-example",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-filesync/public/file-sync-sw.js
+++ b/examples/react-filesync/public/file-sync-sw.js
@@ -1,0 +1,124 @@
+"use strict";
+(() => {
+  // src/worker/file-sync-sw.ts
+  var defaultConfig = {
+    pathPrefix: "/livestore-filesync-files/",
+    cacheRemoteResponses: true
+  };
+  var opfs = {
+    async getRoot() {
+      try {
+        return await navigator.storage.getDirectory();
+      } catch {
+        return null;
+      }
+    },
+    async getFile(path) {
+      const root = await this.getRoot();
+      if (!root) return null;
+      try {
+        const segments = path.split("/").filter((s) => s.length > 0);
+        let current = root;
+        for (let i = 0; i < segments.length - 1; i++) {
+          current = await current.getDirectoryHandle(segments[i]);
+        }
+        const filename = segments[segments.length - 1];
+        const fileHandle = await current.getFileHandle(filename);
+        return await fileHandle.getFile();
+      } catch {
+        return null;
+      }
+    },
+    async writeFile(path, data, mimeType) {
+      const root = await this.getRoot();
+      if (!root) return false;
+      try {
+        const segments = path.split("/").filter((s) => s.length > 0);
+        let current = root;
+        for (let i = 0; i < segments.length - 1; i++) {
+          current = await current.getDirectoryHandle(segments[i], { create: true });
+        }
+        const filename = segments[segments.length - 1];
+        const fileHandle = await current.getFileHandle(filename, { create: true });
+        const writable = await fileHandle.createWritable();
+        await writable.write(new Blob([data], { type: mimeType }));
+        await writable.close();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  };
+  async function handleFileRequest(request, config) {
+    const url = new URL(request.url);
+    const storedPath = url.pathname.startsWith("/") ? url.pathname.slice(1) : url.pathname;
+    const localFile = await opfs.getFile(storedPath);
+    if (localFile) {
+      return new Response(localFile, {
+        headers: {
+          "Content-Type": localFile.type || "application/octet-stream",
+          "Content-Length": String(localFile.size),
+          "X-Source": "opfs"
+        }
+      });
+    }
+    if (config.getRemoteUrl) {
+      const remoteUrl = await config.getRemoteUrl(storedPath);
+      if (remoteUrl) {
+        try {
+          const remoteHeaders = config.getRemoteHeaders ? await config.getRemoteHeaders(storedPath) : null;
+          const response = await fetch(remoteUrl, remoteHeaders ? { headers: remoteHeaders } : void 0);
+          if (response.ok) {
+            if (config.cacheRemoteResponses) {
+              const clonedResponse = response.clone();
+              const data = await clonedResponse.arrayBuffer();
+              const mimeType = clonedResponse.headers.get("Content-Type") || "application/octet-stream";
+              await opfs.writeFile(storedPath, data, mimeType);
+            }
+            const headers = new Headers(response.headers);
+            headers.set("X-Source", "remote");
+            return new Response(response.body, {
+              status: response.status,
+              statusText: response.statusText,
+              headers
+            });
+          }
+        } catch (error) {
+          console.error("Failed to fetch from remote:", error);
+        }
+      }
+    }
+    return new Response("File not found", {
+      status: 404,
+      headers: { "Content-Type": "text/plain" }
+    });
+  }
+  function initFileSyncServiceWorker(config = {}) {
+    const mergedConfig = { ...defaultConfig, ...config };
+    self.addEventListener("fetch", (event) => {
+      const url = new URL(event.request.url);
+      if (event.request.method === "GET" && url.pathname.startsWith(mergedConfig.pathPrefix)) {
+        event.respondWith(handleFileRequest(event.request, mergedConfig));
+      }
+    });
+    self.addEventListener("install", () => {
+      self.skipWaiting();
+    });
+    self.addEventListener("activate", (event) => {
+      event.waitUntil(self.clients.claim());
+    });
+    console.log("[FileSyncSW] Initialized with config:", mergedConfig);
+  }
+
+  // src/worker/file-sync-sw-standalone.ts
+  var params = new URLSearchParams(self.location.search);
+  var filesBaseUrl = params.get("filesBaseUrl") || "";
+  var token = params.get("token") || "";
+  var baseUrl = filesBaseUrl.replace(/\/$/, "");
+  initFileSyncServiceWorker({
+    pathPrefix: "/livestore-filesync-files/",
+    cacheRemoteResponses: true,
+    getRemoteUrl: async (path) => baseUrl ? `${baseUrl}/${path}` : `/${path}`,
+    ...token ? { getRemoteHeaders: async () => ({ Authorization: `Bearer ${token}` }) } : {}
+  });
+})();

--- a/examples/react-filesync/src/App.tsx
+++ b/examples/react-filesync/src/App.tsx
@@ -12,7 +12,7 @@ import { schema, SyncPayload } from "./livestore/schema.ts"
 
 // Allow storeId to be set via query param for testing isolation
 const urlParams = new URLSearchParams(window.location.search)
-const storeId = urlParams.get("storeId") || "react_filesync_store_7"
+const storeId = urlParams.get("storeId") || "react_filesync_store_8"
 const healthCheckIntervalMs = urlParams.get("healthCheckIntervalMs")
   ? Number(urlParams.get("healthCheckIntervalMs"))
   : undefined

--- a/examples/react-filesync/src/components/ImageCard.tsx
+++ b/examples/react-filesync/src/components/ImageCard.tsx
@@ -1,14 +1,7 @@
-import {
-  deleteFile,
-  getFileDisplayState,
-  readFile,
-  resolveFileUrl,
-  rowsToLocalFilesState,
-  updateFile
-} from "@livestore-filesync/core"
+import { deleteFile, getFileDisplayState, readFile, resolveFileUrl, updateFile } from "@livestore-filesync/core"
 import { queryDb } from "@livestore/livestore"
 import { useStore } from "@livestore/react"
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useEffect, useState } from "react"
 import { reactStoreOptions } from "../App.tsx"
 import { tables } from "../livestore/schema.ts"
 import type { FileType } from "../types"
@@ -16,12 +9,11 @@ import type { FileType } from "../types"
 export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
   const store = useStore(reactStoreOptions)
 
-  const localFileStateRows = store.useQuery(queryDb(tables.localFileState.select()))
-  const localFilesState = useMemo(() => rowsToLocalFilesState(localFileStateRows), [localFileStateRows])
-  const displayState = getFileDisplayState(
-    file,
-    localFilesState
+  // Per-file query: only re-renders when THIS file's local state changes
+  const localFileState = store.useQuery(
+    queryDb(tables.localFileState.where({ fileId: file.id }).first())
   )
+  const displayState = getFileDisplayState(file, localFileState ?? undefined)
   const { canDisplay, isUploading, localState: localFile } = displayState
 
   const [src, setSrc] = useState<string | null>(null)

--- a/examples/react-filesync/src/components/ImageCard.tsx
+++ b/examples/react-filesync/src/components/ImageCard.tsx
@@ -1,6 +1,14 @@
-import { deleteFile, getFileDisplayState, readFile, resolveFileUrl, updateFile } from "@livestore-filesync/core"
+import {
+  deleteFile,
+  getFileDisplayState,
+  readFile,
+  resolveFileUrl,
+  rowsToLocalFilesState,
+  updateFile
+} from "@livestore-filesync/core"
+import { queryDb } from "@livestore/livestore"
 import { useStore } from "@livestore/react"
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { reactStoreOptions } from "../App.tsx"
 import { tables } from "../livestore/schema.ts"
 import type { FileType } from "../types"
@@ -8,10 +16,11 @@ import type { FileType } from "../types"
 export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
   const store = useStore(reactStoreOptions)
 
-  const [localFileState] = store.useClientDocument(tables.localFileState)
+  const localFileStateRows = store.useQuery(queryDb(tables.localFileState.select()))
+  const localFilesState = useMemo(() => rowsToLocalFilesState(localFileStateRows), [localFileStateRows])
   const displayState = getFileDisplayState(
     file,
-    localFileState?.localFiles ?? {}
+    localFilesState
   )
   const { canDisplay, isUploading, localState: localFile } = displayState
 

--- a/examples/react-filesync/src/components/SyncStatus.tsx
+++ b/examples/react-filesync/src/components/SyncStatus.tsx
@@ -1,4 +1,4 @@
-import { getSyncStatus, rowsToLocalFilesState } from "@livestore-filesync/core"
+import { getSyncStatus } from "@livestore-filesync/core"
 import { queryDb } from "@livestore/livestore"
 import { useStore } from "@livestore/react"
 import React, { useCallback, useEffect, useMemo, useState } from "react"
@@ -8,8 +8,7 @@ import { tables } from "../livestore/schema.ts"
 export const SyncStatus: React.FC = () => {
   const store = useStore(reactStoreOptions)
   const localFileStateRows = store.useQuery(queryDb(tables.localFileState.select()))
-  const localFilesState = useMemo(() => rowsToLocalFilesState(localFileStateRows), [localFileStateRows])
-  const syncStatus = getSyncStatus(localFilesState)
+  const syncStatus = useMemo(() => getSyncStatus(localFileStateRows), [localFileStateRows])
 
   // Network status (browser's navigator.onLine)
   const [isOnline, setIsOnline] = useState(

--- a/examples/react-filesync/src/components/SyncStatus.tsx
+++ b/examples/react-filesync/src/components/SyncStatus.tsx
@@ -1,13 +1,15 @@
-import { getSyncStatus } from "@livestore-filesync/core"
+import { getSyncStatus, rowsToLocalFilesState } from "@livestore-filesync/core"
+import { queryDb } from "@livestore/livestore"
 import { useStore } from "@livestore/react"
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { reactStoreOptions } from "../App.tsx"
 import { tables } from "../livestore/schema.ts"
 
 export const SyncStatus: React.FC = () => {
   const store = useStore(reactStoreOptions)
-  const [localFileState] = store.useClientDocument(tables.localFileState)
-  const syncStatus = getSyncStatus(localFileState?.localFiles ?? {})
+  const localFileStateRows = store.useQuery(queryDb(tables.localFileState.select()))
+  const localFilesState = useMemo(() => rowsToLocalFilesState(localFileStateRows), [localFileStateRows])
+  const syncStatus = getSyncStatus(localFilesState)
 
   // Network status (browser's navigator.onLine)
   const [isOnline, setIsOnline] = useState(

--- a/examples/react-filesync/vite.config.ts
+++ b/examples/react-filesync/vite.config.ts
@@ -1,8 +1,12 @@
 import { cloudflare } from "@cloudflare/vite-plugin"
 import { livestoreDevtoolsPlugin } from "@livestore/devtools-vite"
 import react from "@vitejs/plugin-react"
+import path from "node:path"
 import process from "node:process"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vite"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const defaultPort = 60004
 
@@ -18,6 +22,9 @@ export default defineConfig({
     livestoreDevtoolsPlugin({ schemaPath: "./src/livestore/schema.ts" })
   ],
   resolve: {
+    alias: {
+      "@livestore/wa-sqlite": path.resolve(__dirname, "node_modules/@livestore/wa-sqlite")
+    },
     dedupe: ["react", "react-dom", "@livestore/livestore", "@livestore/react", "effect"]
   },
   optimizeDeps: {

--- a/examples/react-thumbnail/package.json
+++ b/examples/react-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-thumbnail-example",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-thumbnail/package.json
+++ b/examples/react-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-thumbnail-example",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-thumbnail/package.json
+++ b/examples/react-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-thumbnail-example",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-thumbnail/src/components/SyncStatus.tsx
+++ b/examples/react-thumbnail/src/components/SyncStatus.tsx
@@ -5,7 +5,6 @@ import {
   getSyncStatus,
   onFileSyncEvent,
   removeActiveTransfer,
-  rowsToLocalFilesState,
   updateActiveTransfers
 } from "@livestore-filesync/core"
 import { queryDb } from "@livestore/livestore"
@@ -17,8 +16,7 @@ import { tables } from "../livestore/schema.ts"
 export const SyncStatus: React.FC = () => {
   const store = useStore(reactStoreOptions)
   const localFileStateRows = store.useQuery(queryDb(tables.localFileState.select()))
-  const localFilesState = useMemo(() => rowsToLocalFilesState(localFileStateRows), [localFileStateRows])
-  const syncStatus = getSyncStatus(localFilesState)
+  const syncStatus = useMemo(() => getSyncStatus(localFileStateRows), [localFileStateRows])
 
   // Track active transfer progress
   const [activeTransfers, setActiveTransfers] = useState<ActiveTransfers>({})

--- a/examples/react-thumbnail/src/components/SyncStatus.tsx
+++ b/examples/react-thumbnail/src/components/SyncStatus.tsx
@@ -5,17 +5,20 @@ import {
   getSyncStatus,
   onFileSyncEvent,
   removeActiveTransfer,
+  rowsToLocalFilesState,
   updateActiveTransfers
 } from "@livestore-filesync/core"
+import { queryDb } from "@livestore/livestore"
 import { useStore } from "@livestore/react"
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { reactStoreOptions } from "../App.tsx"
 import { tables } from "../livestore/schema.ts"
 
 export const SyncStatus: React.FC = () => {
   const store = useStore(reactStoreOptions)
-  const [localFileState] = store.useClientDocument(tables.localFileState)
-  const syncStatus = getSyncStatus(localFileState?.localFiles ?? {})
+  const localFileStateRows = store.useQuery(queryDb(tables.localFileState.select()))
+  const localFilesState = useMemo(() => rowsToLocalFilesState(localFileStateRows), [localFileStateRows])
+  const syncStatus = getSyncStatus(localFilesState)
 
   // Track active transfer progress
   const [activeTransfers, setActiveTransfers] = useState<ActiveTransfers>({})

--- a/examples/react-thumbnail/src/livestore/schema.ts
+++ b/examples/react-thumbnail/src/livestore/schema.ts
@@ -18,7 +18,8 @@ export const events = {
 }
 
 const materializers = State.SQLite.materializers(events, {
-  ...fileSyncSchema.createMaterializers(tables)
+  ...fileSyncSchema.createMaterializers(tables),
+  ...thumbnailSchema.createMaterializers(tables)
 })
 
 const state = State.SQLite.makeState({ tables, materializers })

--- a/examples/react-thumbnail/vite.config.ts
+++ b/examples/react-thumbnail/vite.config.ts
@@ -1,8 +1,12 @@
 import { cloudflare } from "@cloudflare/vite-plugin"
 import { livestoreDevtoolsPlugin } from "@livestore/devtools-vite"
 import react from "@vitejs/plugin-react"
+import path from "node:path"
 import process from "node:process"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vite"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const defaultPort = 60006
 
@@ -18,6 +22,9 @@ export default defineConfig({
     livestoreDevtoolsPlugin({ schemaPath: "./src/livestore/schema.ts" })
   ],
   resolve: {
+    alias: {
+      "@livestore/wa-sqlite": path.resolve(__dirname, "node_modules/@livestore/wa-sqlite")
+    },
     dedupe: ["react", "react-dom", "@livestore/livestore", "@livestore/react", "effect"]
   },
   optimizeDeps: {

--- a/examples/vue-filesync/package.json
+++ b/examples/vue-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-example",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/vue-filesync/package.json
+++ b/examples/vue-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-example",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/vue-filesync/package.json
+++ b/examples/vue-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-example",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/vue-filesync/src/components/ImageCard.vue
+++ b/examples/vue-filesync/src/components/ImageCard.vue
@@ -6,7 +6,6 @@ import {
   getFileDisplayState,
   readFile,
   resolveFileUrl,
-  rowsToLocalFilesState,
   updateFile,
 } from '@livestore-filesync/core'
 import { queryDb } from '@livestore/livestore'
@@ -20,12 +19,12 @@ const props = defineProps<{
 
 const { store } = useStore()
 
-const localFileStateRows = useQuery(queryDb(tables.localFileState.select()))
-const localFilesState = computed(() => rowsToLocalFilesState(localFileStateRows.value))
-const localFile = computed(() => localFilesState.value[props.file.id])
+// Per-file query: only re-renders when THIS file's local state changes
+const localFileState = useQuery(queryDb(tables.localFileState.where({ fileId: props.file.id }).first()))
+const localFile = computed(() => localFileState.value)
 
 const displayState = computed(() =>
-  getFileDisplayState(props.file, localFilesState.value)
+  getFileDisplayState(props.file, localFileState.value ?? undefined)
 )
 const canDisplay = computed(() => displayState.value.canDisplay)
 const isUploading = computed(() => displayState.value.isUploading)

--- a/examples/vue-filesync/src/components/ImageCard.vue
+++ b/examples/vue-filesync/src/components/ImageCard.vue
@@ -6,9 +6,11 @@ import {
   getFileDisplayState,
   readFile,
   resolveFileUrl,
+  rowsToLocalFilesState,
   updateFile,
 } from '@livestore-filesync/core'
-import { useStore } from 'vue-livestore'
+import { queryDb } from '@livestore/livestore'
+import { useStore, useQuery } from 'vue-livestore'
 import type { FileType } from '../types'
 import { invertImageFile } from '../utils/image.utils'
 
@@ -18,11 +20,12 @@ const props = defineProps<{
 
 const { store } = useStore()
 
-const { localFiles } = store.useClientDocument(tables.localFileState)
-const localFile = computed(() => localFiles.value[props.file.id])
+const localFileStateRows = useQuery(queryDb(tables.localFileState.select()))
+const localFilesState = computed(() => rowsToLocalFilesState(localFileStateRows.value))
+const localFile = computed(() => localFilesState.value[props.file.id])
 
 const displayState = computed(() =>
-  getFileDisplayState(props.file, localFiles.value)
+  getFileDisplayState(props.file, localFilesState.value)
 )
 const canDisplay = computed(() => displayState.value.canDisplay)
 const isUploading = computed(() => displayState.value.isUploading)

--- a/examples/vue-filesync/src/components/SyncStatus.vue
+++ b/examples/vue-filesync/src/components/SyncStatus.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted } from 'vue'
-import { useStore } from 'vue-livestore'
+import { useStore, useQuery } from 'vue-livestore'
+import { queryDb } from '@livestore/livestore'
 import {
   getSyncStatus,
+  rowsToLocalFilesState,
   onFileSyncEvent,
   createActiveTransferProgress,
   updateActiveTransfers,
@@ -13,10 +15,10 @@ import {
 import { tables } from '../livestore/schema'
 
 const { store } = useStore()
-const { localFiles } = store.useClientDocument(tables.localFileState)
+const localFileStateRows = useQuery(queryDb(tables.localFileState.select()))
 
 const syncStatus = computed(() => {
-  return getSyncStatus(localFiles.value ?? {})
+  return getSyncStatus(rowsToLocalFilesState(localFileStateRows.value))
 })
 
 // Track active transfer progress

--- a/examples/vue-filesync/src/components/SyncStatus.vue
+++ b/examples/vue-filesync/src/components/SyncStatus.vue
@@ -4,7 +4,6 @@ import { useStore, useQuery } from 'vue-livestore'
 import { queryDb } from '@livestore/livestore'
 import {
   getSyncStatus,
-  rowsToLocalFilesState,
   onFileSyncEvent,
   createActiveTransferProgress,
   updateActiveTransfers,
@@ -17,9 +16,7 @@ import { tables } from '../livestore/schema'
 const { store } = useStore()
 const localFileStateRows = useQuery(queryDb(tables.localFileState.select()))
 
-const syncStatus = computed(() => {
-  return getSyncStatus(rowsToLocalFilesState(localFileStateRows.value))
-})
+const syncStatus = computed(() => getSyncStatus(localFileStateRows.value))
 
 // Track active transfer progress
 const activeTransfers = ref<ActiveTransfers>({})

--- a/examples/vue-filesync/vite.config.ts
+++ b/examples/vue-filesync/vite.config.ts
@@ -1,8 +1,12 @@
 import { cloudflare } from "@cloudflare/vite-plugin"
 import { livestoreDevtoolsPlugin } from "@livestore/devtools-vite"
 import vue from "@vitejs/plugin-vue"
+import path from "node:path"
 import process from "node:process"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vite"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const defaultPort = 60004
 
@@ -18,6 +22,9 @@ export default defineConfig({
     livestoreDevtoolsPlugin({ schemaPath: "./src/livestore/schema.ts" })
   ],
   resolve: {
+    alias: {
+      "@livestore/wa-sqlite": path.resolve(__dirname, "node_modules/@livestore/wa-sqlite")
+    },
     dedupe: ["vue", "@livestore/livestore", "vue-livestore", "effect"]
   },
   optimizeDeps: {

--- a/examples/vue-thumbnail/package.json
+++ b/examples/vue-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-thumbnail-example",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/vue-thumbnail/package.json
+++ b/examples/vue-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-thumbnail-example",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/vue-thumbnail/package.json
+++ b/examples/vue-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-thumbnail-example",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/vue-thumbnail/src/components/SyncStatus.vue
+++ b/examples/vue-thumbnail/src/components/SyncStatus.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted } from 'vue'
-import { useStore } from 'vue-livestore'
+import { useStore, useQuery } from 'vue-livestore'
+import { queryDb } from '@livestore/livestore'
 import {
   getSyncStatus,
+  rowsToLocalFilesState,
   onFileSyncEvent,
   createActiveTransferProgress,
   updateActiveTransfers,
@@ -13,10 +15,10 @@ import {
 import { tables } from '../livestore/schema'
 
 const { store } = useStore()
-const { localFiles } = store.useClientDocument(tables.localFileState)
+const localFileStateRows = useQuery(queryDb(tables.localFileState.select()))
 
 const syncStatus = computed(() => {
-  return getSyncStatus(localFiles.value ?? {})
+  return getSyncStatus(rowsToLocalFilesState(localFileStateRows.value))
 })
 
 // Track active transfer progress

--- a/examples/vue-thumbnail/src/components/SyncStatus.vue
+++ b/examples/vue-thumbnail/src/components/SyncStatus.vue
@@ -4,7 +4,6 @@ import { useStore, useQuery } from 'vue-livestore'
 import { queryDb } from '@livestore/livestore'
 import {
   getSyncStatus,
-  rowsToLocalFilesState,
   onFileSyncEvent,
   createActiveTransferProgress,
   updateActiveTransfers,
@@ -17,9 +16,7 @@ import { tables } from '../livestore/schema'
 const { store } = useStore()
 const localFileStateRows = useQuery(queryDb(tables.localFileState.select()))
 
-const syncStatus = computed(() => {
-  return getSyncStatus(rowsToLocalFilesState(localFileStateRows.value))
-})
+const syncStatus = computed(() => getSyncStatus(localFileStateRows.value))
 
 // Track active transfer progress
 const activeTransfers = ref<ActiveTransfers>({})

--- a/examples/vue-thumbnail/src/livestore/schema.ts
+++ b/examples/vue-thumbnail/src/livestore/schema.ts
@@ -18,7 +18,8 @@ export const events = {
 }
 
 const materializers = State.SQLite.materializers(events, {
-  ...fileSyncSchema.createMaterializers(tables)
+  ...fileSyncSchema.createMaterializers(tables),
+  ...thumbnailSchema.createMaterializers(tables)
 })
 
 const state = State.SQLite.makeState({ tables, materializers })

--- a/examples/vue-thumbnail/vite.config.ts
+++ b/examples/vue-thumbnail/vite.config.ts
@@ -1,8 +1,12 @@
 import { cloudflare } from "@cloudflare/vite-plugin"
 import { livestoreDevtoolsPlugin } from "@livestore/devtools-vite"
 import vue from "@vitejs/plugin-vue"
+import path from "node:path"
 import process from "node:process"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vite"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const defaultPort = 60005
 
@@ -23,6 +27,9 @@ export default defineConfig({
     livestoreDevtoolsPlugin({ schemaPath: "./src/livestore/schema.ts" })
   ],
   resolve: {
+    alias: {
+      "@livestore/wa-sqlite": path.resolve(__dirname, "node_modules/@livestore/wa-sqlite")
+    },
     dedupe: ["vue", "@livestore/livestore", "vue-livestore", "effect"]
   },
   optimizeDeps: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "license": "MIT",
   "description": "Framework-agnostic file syncing for LiveStore applications with OPFS support",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "license": "MIT",
   "description": "Framework-agnostic file syncing for LiveStore applications with OPFS support",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/core",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "license": "MIT",
   "description": "Framework-agnostic file syncing for LiveStore applications with OPFS support",

--- a/packages/core/src/api/createFileSync.ts
+++ b/packages/core/src/api/createFileSync.ts
@@ -338,6 +338,9 @@ export function createFileSync(config: CreateFileSyncConfig): FileSyncInstance {
         await runEffect(Scope.extend(fileSync.start(), scope))
       } catch (error) {
         console.error("[createFileSync] Error during start:", error)
+        // Surface initialization failures to event listeners so callers
+        // can detect and handle them (not just console.error)
+        options.onEvent?.({ type: "sync:error", error, context: "start" })
       }
     })()
   }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -47,6 +47,5 @@ export {
   createActiveTransferProgress,
   getSyncStatus,
   removeActiveTransfer,
-  rowsToLocalFilesState,
   updateActiveTransfers
 } from "./sync-status.js"

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -47,5 +47,6 @@ export {
   createActiveTransferProgress,
   getSyncStatus,
   removeActiveTransfer,
+  rowsToLocalFilesState,
   updateActiveTransfers
 } from "./sync-status.js"

--- a/packages/core/src/api/singleton.ts
+++ b/packages/core/src/api/singleton.ts
@@ -22,7 +22,9 @@ const REQUIRED_EVENTS = [
   "v1.FileCreated",
   "v1.FileUpdated",
   "v1.FileDeleted",
-  "localFileStateSet"
+  "v1.LocalFileStateUpsert",
+  "v1.LocalFileStateRemove",
+  "v1.LocalFileStateClear"
 ] as const
 
 type SchemaFallback = Pick<SyncSchema, "tables" | "events"> & {

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -266,8 +266,7 @@ export function createFileSyncSchema() {
       appTables.localFileState.delete().where({ fileId }),
       appTables.localFileState.insert({ fileId, path, localHash, downloadStatus, uploadStatus, lastSyncError })
     ],
-    "v1.LocalFileStateRemove": ({ fileId }: { fileId: string }) =>
-      appTables.localFileState.delete().where({ fileId }),
+    "v1.LocalFileStateRemove": ({ fileId }: { fileId: string }) => appTables.localFileState.delete().where({ fileId }),
     "v1.LocalFileStateClear": () => appTables.localFileState.delete()
   })
 

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -7,6 +7,12 @@
  * Types are derived from these schemas in types/index.ts to ensure
  * a single source of truth.
  *
+ * ARCHITECTURE NOTE: localFileState uses a regular SQLite table with
+ * clientOnly events instead of a clientDocument with Schema.Record.
+ * This prevents rebase conflicts during concurrent tab operations by
+ * storing each file's state as a separate row rather than a single JSON blob.
+ * See: https://github.com/livestorejs/livestore/issues/998
+ *
  * @example
  * ```typescript
  * import { createFileSyncSchema } from 'livestore-filesync/schema'
@@ -39,7 +45,7 @@
  * @module
  */
 
-import { Events, EventSequenceNumber, Schema, SessionIdSymbol, State } from "@livestore/livestore"
+import { Events, EventSequenceNumber, Schema, State } from "@livestore/livestore"
 
 // ============================================
 // Schema Definitions (Source of Truth)
@@ -52,6 +58,7 @@ export const TransferStatusSchema = Schema.Literal("pending", "queued", "inProgr
 
 /**
  * Local file state schema - tracks sync status for a single file
+ * This is used for both the row type and the event payload.
  */
 export const LocalFileStateSchema = Schema.Struct({
   path: Schema.String,
@@ -62,7 +69,20 @@ export const LocalFileStateSchema = Schema.Struct({
 })
 
 /**
+ * Local file state row schema - includes the fileId for the table
+ */
+export const LocalFileStateRowSchema = Schema.Struct({
+  fileId: Schema.String,
+  path: Schema.String,
+  localHash: Schema.String,
+  downloadStatus: TransferStatusSchema,
+  uploadStatus: TransferStatusSchema,
+  lastSyncError: Schema.String
+})
+
+/**
  * Map of file IDs to local file states schema
+ * This type is kept for backwards compatibility with consumers.
  */
 export const LocalFilesStateSchema = Schema.Record({
   key: Schema.String,
@@ -119,6 +139,7 @@ export const FileDeletedPayloadSchema = Schema.Struct({
 type FileCreatedPayload = typeof FileCreatedPayloadSchema.Type
 type FileUpdatedPayload = typeof FileUpdatedPayloadSchema.Type
 type FileDeletedPayload = typeof FileDeletedPayloadSchema.Type
+type LocalFileStateRow = typeof LocalFileStateRowSchema.Type
 
 /**
  * Creates file sync schema components (tables, events, materializers)
@@ -145,16 +166,24 @@ export function createFileSyncSchema() {
         deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromNumber })
       }
     }),
-    localFileState: State.SQLite.clientDocument({
+    /**
+     * Local file state table - stores sync status for each file as individual rows.
+     *
+     * This replaces the previous clientDocument approach which used Schema.Record
+     * to store all file states in a single JSON blob. The row-based approach:
+     * - Reduces rebase conflicts by isolating changes to individual rows
+     * - Works better with SQLite's changeset extension
+     * - Shares state across all tabs (no session isolation needed for OPFS)
+     */
+    localFileState: State.SQLite.table({
       name: "localFileState",
-      schema: Schema.Struct({
-        localFiles: LocalFilesStateSchema
-      }),
-      default: {
-        id: SessionIdSymbol,
-        value: {
-          localFiles: {}
-        }
+      columns: {
+        fileId: State.SQLite.text({ primaryKey: true }),
+        path: State.SQLite.text({ default: "" }),
+        localHash: State.SQLite.text({ default: "" }),
+        downloadStatus: State.SQLite.text({ default: "pending" }),
+        uploadStatus: State.SQLite.text({ default: "pending" }),
+        lastSyncError: State.SQLite.text({ default: "" })
       }
     }),
     fileSyncCursor: State.SQLite.clientDocument({
@@ -172,6 +201,7 @@ export function createFileSyncSchema() {
 
   // Events
   const events = {
+    // Synced events for file CRUD (sync to remote)
     fileCreated: Events.synced({
       name: "v1.FileCreated",
       schema: FileCreatedPayloadSchema
@@ -184,12 +214,29 @@ export function createFileSyncSchema() {
       name: "v1.FileDeleted",
       schema: FileDeletedPayloadSchema
     }),
-    localFileStateSet: tables.localFileState.set,
+
+    // Client-only events for local file state (sync between tabs, not to remote)
+    // These use individual row operations to avoid Schema.Record rebase conflicts
+    localFileStateUpsert: Events.clientOnly({
+      name: "v1.LocalFileStateUpsert",
+      schema: LocalFileStateRowSchema
+    }),
+    localFileStateRemove: Events.clientOnly({
+      name: "v1.LocalFileStateRemove",
+      schema: Schema.Struct({ fileId: Schema.String })
+    }),
+    localFileStateClear: Events.clientOnly({
+      name: "v1.LocalFileStateClear",
+      schema: Schema.Struct({})
+    }),
+
+    // Cursor for tracking sync progress (still uses clientDocument - single value, low conflict risk)
     fileSyncCursorSet: tables.fileSyncCursor.set
   }
 
   // Create materializers function
   const createMaterializers = <T extends typeof tables>(appTables: T) => ({
+    // File CRUD materializers
     "v1.FileCreated": ({
       contentHash,
       createdAt,
@@ -204,7 +251,24 @@ export function createFileSyncSchema() {
       remoteKey,
       updatedAt
     }: FileUpdatedPayload) => appTables.files.update({ path, remoteKey, contentHash, updatedAt }).where({ id }),
-    "v1.FileDeleted": ({ deletedAt, id }: FileDeletedPayload) => appTables.files.update({ deletedAt }).where({ id })
+    "v1.FileDeleted": ({ deletedAt, id }: FileDeletedPayload) => appTables.files.update({ deletedAt }).where({ id }),
+
+    // Local file state materializers - row-level operations
+    // Uses delete + insert pattern for upsert since LiveStore doesn't have native upsert
+    "v1.LocalFileStateUpsert": ({
+      downloadStatus,
+      fileId,
+      lastSyncError,
+      localHash,
+      path,
+      uploadStatus
+    }: LocalFileStateRow) => [
+      appTables.localFileState.delete().where({ fileId }),
+      appTables.localFileState.insert({ fileId, path, localHash, downloadStatus, uploadStatus, lastSyncError })
+    ],
+    "v1.LocalFileStateRemove": ({ fileId }: { fileId: string }) =>
+      appTables.localFileState.delete().where({ fileId }),
+    "v1.LocalFileStateClear": () => appTables.localFileState.delete()
   })
 
   return {
@@ -214,6 +278,7 @@ export function createFileSyncSchema() {
     schemas: {
       TransferStatusSchema,
       LocalFileStateSchema,
+      LocalFileStateRowSchema,
       LocalFilesStateSchema,
       FileSyncCursorSchema,
       FileCreatedPayloadSchema,

--- a/packages/core/src/services/file-sync/FileSync.storage.test.ts
+++ b/packages/core/src/services/file-sync/FileSync.storage.test.ts
@@ -449,7 +449,10 @@ describe("FileSync - Preprocessor integration", () => {
 
       // Second call (update) fails in preprocessor
       const result = runtime.runPromise(
-        Scope.extend(fileSync.updateFile(saved.fileId, new File(["updated"], "test.txt", { type: "text/plain" })), scope)
+        Scope.extend(
+          fileSync.updateFile(saved.fileId, new File(["updated"], "test.txt", { type: "text/plain" })),
+          scope
+        )
       )
 
       await expect(result).rejects.toThrow("Preprocessor failed for test.txt: Preprocessor exploded on update")

--- a/packages/core/src/services/file-sync/FileSync.test.ts
+++ b/packages/core/src/services/file-sync/FileSync.test.ts
@@ -347,9 +347,10 @@ describe("FileSync - Offline Transition", () => {
       expect(state[fileId1]?.lastSyncError).toBe("File too large")
       expect(state[fileId2]?.uploadStatus).toBe("queued")
 
-      // Go online then offline — this triggers the goOffline path
+      // Go online then immediately offline — this triggers the goOffline path.
+      // No delay between to avoid the executor picking up the error file and
+      // overwriting the manually-set lastSyncError.
       await runtime.runPromise(fileSync.setOnline(true))
-      await delay(20)
       await runtime.runPromise(fileSync.setOnline(false))
       await delay(20)
 

--- a/packages/core/src/services/file-sync/FileSync.test.ts
+++ b/packages/core/src/services/file-sync/FileSync.test.ts
@@ -312,12 +312,18 @@ describe("FileSync - Offline Transition", () => {
       await runtime.runPromise(localStorage.writeFile(path2, new File(["data2"], "test2.txt")))
 
       store.commit(events.fileCreated({
-        id: fileId1, path: path1, contentHash: "hash1",
-        createdAt: new Date(), updatedAt: new Date()
+        id: fileId1,
+        path: path1,
+        contentHash: "hash1",
+        createdAt: new Date(),
+        updatedAt: new Date()
       }))
       store.commit(events.fileCreated({
-        id: fileId2, path: path2, contentHash: "hash2",
-        createdAt: new Date(), updatedAt: new Date()
+        id: fileId2,
+        path: path2,
+        contentHash: "hash2",
+        createdAt: new Date(),
+        updatedAt: new Date()
       }))
 
       // Start offline so uploads queue but don't run
@@ -327,7 +333,9 @@ describe("FileSync - Offline Transition", () => {
 
       // Manually set file1 to "error" state (simulating a non-network failure)
       const stateManager = await runtime.runPromise(
-        Effect.gen(function*() { return yield* LocalFileStateManager })
+        Effect.gen(function*() {
+          return yield* LocalFileStateManager
+        })
       )
       await runtime.runPromise(
         stateManager.setTransferError(fileId1, "upload", "error", "File too large")
@@ -1231,12 +1239,18 @@ describe("FileSync - Per-Event Error Handling", () => {
 
       // Commit events before start
       store.commit(events.fileCreated({
-        id: fileId1, path: path1, contentHash: "hash1",
-        createdAt: new Date(), updatedAt: new Date()
+        id: fileId1,
+        path: path1,
+        contentHash: "hash1",
+        createdAt: new Date(),
+        updatedAt: new Date()
       }))
       store.commit(events.fileCreated({
-        id: fileId2, path: path2, contentHash: "hash2",
-        createdAt: new Date(), updatedAt: new Date()
+        id: fileId2,
+        path: path2,
+        contentHash: "hash2",
+        createdAt: new Date(),
+        updatedAt: new Date()
       }))
 
       await runtime.runPromise(fileSync.setOnline(false))

--- a/packages/core/src/services/file-sync/FileSync.test.ts
+++ b/packages/core/src/services/file-sync/FileSync.test.ts
@@ -888,16 +888,13 @@ describe("FileSync - Error State Recovery", () => {
       // Manually inject error state into localFileState
       const { schema, store } = deps
       store.commit(
-        schema.events.localFileStateSet({
-          localFiles: {
-            [fileId]: {
-              path,
-              localHash: "error-test-hash",
-              uploadStatus: "error",
-              downloadStatus: "done",
-              lastSyncError: "Simulated error"
-            }
-          }
+        schema.events.localFileStateUpsert({
+          fileId,
+          path,
+          localHash: "error-test-hash",
+          uploadStatus: "error",
+          downloadStatus: "done",
+          lastSyncError: "Simulated error"
         })
       )
 
@@ -960,23 +957,23 @@ describe("FileSync - Error State Recovery", () => {
       // Inject error states
       const { schema, store } = deps
       store.commit(
-        schema.events.localFileStateSet({
-          localFiles: {
-            [fileId1]: {
-              path: path1,
-              localHash: "retry-hash-1",
-              uploadStatus: "error",
-              downloadStatus: "done",
-              lastSyncError: "Upload failed"
-            },
-            [fileId2]: {
-              path: path2,
-              localHash: "retry-hash-2",
-              uploadStatus: "done",
-              downloadStatus: "error",
-              lastSyncError: "Download failed"
-            }
-          }
+        schema.events.localFileStateUpsert({
+          fileId: fileId1,
+          path: path1,
+          localHash: "retry-hash-1",
+          uploadStatus: "error",
+          downloadStatus: "done",
+          lastSyncError: "Upload failed"
+        })
+      )
+      store.commit(
+        schema.events.localFileStateUpsert({
+          fileId: fileId2,
+          path: path2,
+          localHash: "retry-hash-2",
+          uploadStatus: "done",
+          downloadStatus: "error",
+          lastSyncError: "Download failed"
         })
       )
 
@@ -1056,16 +1053,13 @@ describe("FileSync - Error State Recovery", () => {
 
       const { schema, store } = deps
       store.commit(
-        schema.events.localFileStateSet({
-          localFiles: {
-            [fileId]: {
-              path,
-              localHash: "clear-error-hash",
-              uploadStatus: "error",
-              downloadStatus: "done",
-              lastSyncError: "This error should be cleared"
-            }
-          }
+        schema.events.localFileStateUpsert({
+          fileId,
+          path,
+          localHash: "clear-error-hash",
+          uploadStatus: "error",
+          downloadStatus: "done",
+          lastSyncError: "This error should be cleared"
         })
       )
 

--- a/packages/core/src/services/file-sync/FileSync.ts
+++ b/packages/core/src/services/file-sync/FileSync.ts
@@ -1539,6 +1539,9 @@ export const makeFileSync = (
         const existingFile = yield* getFile(fileId)
         if (!existingFile) return
 
+        // Cancel any pending download so it doesn't write the file back after deletion
+        yield* executor.cancelDownload(fileId)
+
         yield* deleteFileRecord(fileId)
 
         yield* localStorage.deleteFile(existingFile.path).pipe(Effect.catchAll(() => Effect.void))

--- a/packages/core/src/services/file-sync/FileSync.ts
+++ b/packages/core/src/services/file-sync/FileSync.ts
@@ -1286,7 +1286,9 @@ export const makeFileSync = (
 
         yield* Effect.logWarning(
           `[FileSync] Heartbeat: stream stalled - upstream at ${EventSequenceNumber.Client.toString(upstreamHead)}, ` +
-            `last batch at ${EventSequenceNumber.Client.toString(lastBatchCursor)}, ${timeSinceLastBatch}ms since last batch`
+            `last batch at ${
+              EventSequenceNumber.Client.toString(lastBatchCursor)
+            }, ${timeSinceLastBatch}ms since last batch`
         )
         yield* emit({ type: "sync:heartbeat-recovery", reason: "stream-stalled" })
         yield* startEventStream()

--- a/packages/core/src/services/local-file-state/LocalFileStateManager.ts
+++ b/packages/core/src/services/local-file-state/LocalFileStateManager.ts
@@ -1,12 +1,19 @@
 /**
  * LocalFileStateManager Service
  *
- * Centralized manager for all LocalFilesState mutations. Uses a semaphore
- * to ensure atomic read-modify-write operations, preventing race conditions
- * when multiple concurrent operations try to update the state.
+ * Centralized manager for all LocalFilesState mutations. Uses SQLite row-level
+ * operations to avoid the rebase conflicts that occur with Schema.Record in
+ * clientDocument.
  *
- * All state changes must go through this service - it is the single owner
- * of LocalFilesState mutations.
+ * Each file's state is stored as a separate row in the localFileState table,
+ * with changes committed via clientOnly events that sync between tabs but not
+ * to the remote backend.
+ *
+ * ARCHITECTURE NOTE: This service uses individual row operations instead of
+ * atomic JSON updates. This prevents the "function signature mismatch" errors
+ * during rebase rollback that occur when multiple tabs update a Schema.Record
+ * clientDocument simultaneously.
+ * See: https://github.com/livestorejs/livestore/issues/998
  *
  * @module
  */
@@ -16,10 +23,22 @@ import type { LiveStoreDeps } from "../../livestore/types.js"
 import type { LocalFilesState, LocalFileState, TransferStatus } from "../../types/index.js"
 
 /**
+ * Row type for the localFileState table
+ */
+interface LocalFileStateTableRow {
+  fileId: string
+  path: string
+  localHash: string
+  downloadStatus: string
+  uploadStatus: string
+  lastSyncError: string
+}
+
+/**
  * LocalFileStateManager service interface
  *
- * Provides atomic operations for updating the LocalFilesState client document.
- * All methods are serialized internally to prevent race conditions.
+ * Provides operations for updating the LocalFilesState stored in SQLite rows.
+ * Each file's state is stored as a separate row to avoid rebase conflicts.
  */
 export interface LocalFileStateManagerService {
   /**
@@ -71,13 +90,15 @@ export interface LocalFileStateManagerService {
   readonly replaceState: (state: LocalFilesState) => Effect.Effect<void>
 
   /**
-   * Get the current state (read-only, no locking needed).
+   * Get the current state (read-only).
+   * Returns a map of fileId -> LocalFileState reconstructed from table rows.
    */
   readonly getState: () => Effect.Effect<LocalFilesState>
 
   /**
-   * Apply a custom updater function atomically.
-   * Use this for complex updates that don't fit the other methods.
+   * Apply a custom updater function.
+   * The updater receives the current state and returns the new state.
+   * Changes are computed as a diff and committed as individual row operations.
    */
   readonly atomicUpdate: (
     updater: (state: LocalFilesState) => LocalFilesState
@@ -102,47 +123,71 @@ export const makeLocalFileStateManager = (
     const { schema, store } = deps
     const { events, queryDb, tables } = schema
 
-    // Create a semaphore with 1 permit to ensure only one update runs at a time
-    const semaphore = yield* Effect.makeSemaphore(1)
+    /**
+     * Convert a table row to LocalFileState (without fileId)
+     */
+    const rowToState = (row: LocalFileStateTableRow): LocalFileState => ({
+      path: row.path,
+      localHash: row.localHash,
+      downloadStatus: row.downloadStatus as TransferStatus,
+      uploadStatus: row.uploadStatus as TransferStatus,
+      lastSyncError: row.lastSyncError
+    })
 
-    // Read current state from LiveStore
+    /**
+     * Read current state from SQLite table as a map
+     */
     const readState = (): LocalFilesState => {
-      const doc = store.query<{ localFiles?: LocalFilesState }>(
-        queryDb(tables.localFileState.get())
+      const rows = store.query<Array<LocalFileStateTableRow>>(
+        queryDb(tables.localFileState.select())
       )
-      return doc.localFiles ?? {}
+      const state: Record<string, LocalFileState> = {}
+      for (const row of rows) {
+        state[row.fileId] = rowToState(row)
+      }
+      return state
     }
 
-    // Commit state to LiveStore
-    const commitState = (state: LocalFilesState): void => {
-      store.commit(events.localFileStateSet({ localFiles: state }))
+    /**
+     * Read a single file's state from the table
+     */
+    const readFileState = (fileId: string): LocalFileState | undefined => {
+      const rows = store.query<Array<LocalFileStateTableRow>>(
+        queryDb(tables.localFileState.where({ fileId }))
+      )
+      if (rows.length === 0) return undefined
+      return rowToState(rows[0]!)
     }
 
-    // Core atomic update - all other methods use this
-    // Uses semaphore.withPermits(1) to ensure only one update runs at a time
-    const atomicUpdate = (
-      updater: (state: LocalFilesState) => LocalFilesState
-    ): Effect.Effect<void> =>
-      semaphore.withPermits(1)(
-        Effect.sync(() => {
-          const currentState = readState()
-          const nextState = updater(currentState)
-          // Only commit if state actually changed (referential equality check)
-          if (nextState !== currentState) {
-            commitState(nextState)
-          }
+    /**
+     * Commit an upsert for a single file
+     */
+    const commitUpsert = (fileId: string, state: LocalFileState): void => {
+      store.commit(
+        events.localFileStateUpsert({
+          fileId,
+          path: state.path,
+          localHash: state.localHash,
+          downloadStatus: state.downloadStatus,
+          uploadStatus: state.uploadStatus,
+          lastSyncError: state.lastSyncError
         })
       )
+    }
+
+    /**
+     * Commit a remove for a single file
+     */
+    const commitRemove = (fileId: string): void => {
+      store.commit(events.localFileStateRemove({ fileId }))
+    }
 
     // Set complete state for a single file
     const setFileState = (
       fileId: string,
       state: LocalFileState
     ): Effect.Effect<void> =>
-      atomicUpdate((currentState) => ({
-        ...currentState,
-        [fileId]: state
-      }))
+      Effect.sync(() => commitUpsert(fileId, state))
 
     // Update transfer status for a file
     const setTransferStatus = (
@@ -150,15 +195,16 @@ export const makeLocalFileStateManager = (
       action: "upload" | "download",
       status: TransferStatus
     ): Effect.Effect<void> =>
-      atomicUpdate((currentState) => {
-        const existing = currentState[fileId]
-        if (!existing) return currentState // No-op if file doesn't exist
+      Effect.sync(() => {
+        const existing = readFileState(fileId)
+        if (!existing) return // No-op if file doesn't exist
 
-        const field = action === "upload" ? "uploadStatus" : "downloadStatus"
-        return {
-          ...currentState,
-          [fileId]: { ...existing, [field]: status }
-        }
+        const updatedState: LocalFileState =
+          action === "upload"
+            ? { ...existing, uploadStatus: status }
+            : { ...existing, downloadStatus: status }
+
+        commitUpsert(fileId, updatedState)
       })
 
     // Update transfer status and set error
@@ -168,37 +214,93 @@ export const makeLocalFileStateManager = (
       status: TransferStatus,
       error: string
     ): Effect.Effect<void> =>
-      atomicUpdate((currentState) => {
-        const existing = currentState[fileId]
-        if (!existing) return currentState // No-op if file doesn't exist
+      Effect.sync(() => {
+        const existing = readFileState(fileId)
+        if (!existing) return // No-op if file doesn't exist
 
-        const field = action === "upload" ? "uploadStatus" : "downloadStatus"
-        return {
-          ...currentState,
-          [fileId]: { ...existing, [field]: status, lastSyncError: error }
-        }
+        const updatedState: LocalFileState =
+          action === "upload"
+            ? { ...existing, uploadStatus: status, lastSyncError: error }
+            : { ...existing, downloadStatus: status, lastSyncError: error }
+
+        commitUpsert(fileId, updatedState)
       })
 
     // Remove a file's state
     const removeFile = (fileId: string): Effect.Effect<void> =>
-      atomicUpdate((currentState) => {
-        if (!(fileId in currentState)) return currentState // No-op
-        const { [fileId]: _, ...rest } = currentState
-        return rest
-      })
+      Effect.sync(() => commitRemove(fileId))
 
     // Merge files into state
     const mergeFiles = (patch: LocalFilesState): Effect.Effect<void> =>
-      atomicUpdate((currentState) => ({
-        ...currentState,
-        ...patch
-      }))
+      Effect.sync(() => {
+        for (const [fileId, state] of Object.entries(patch)) {
+          commitUpsert(fileId, state)
+        }
+      })
 
     // Replace entire state
-    const replaceState = (state: LocalFilesState): Effect.Effect<void> => atomicUpdate(() => state)
+    const replaceState = (newState: LocalFilesState): Effect.Effect<void> =>
+      Effect.sync(() => {
+        // Get current file IDs
+        const currentState = readState()
+        const currentIds = new Set(Object.keys(currentState))
+        const newIds = new Set(Object.keys(newState))
 
-    // Get current state (no lock needed for reads)
-    const getState = (): Effect.Effect<LocalFilesState> => Effect.sync(readState)
+        // Remove files that are not in the new state
+        for (const fileId of currentIds) {
+          if (!newIds.has(fileId)) {
+            commitRemove(fileId)
+          }
+        }
+
+        // Upsert all files in the new state
+        for (const [fileId, state] of Object.entries(newState)) {
+          commitUpsert(fileId, state)
+        }
+      })
+
+    // Get current state (read-only)
+    const getState = (): Effect.Effect<LocalFilesState> =>
+      Effect.sync(readState)
+
+    // Apply a custom updater function
+    const atomicUpdate = (
+      updater: (state: LocalFilesState) => LocalFilesState
+    ): Effect.Effect<void> =>
+      Effect.sync(() => {
+        const currentState = readState()
+        const nextState = updater(currentState)
+
+        // If state didn't change (same reference), skip
+        if (nextState === currentState) return
+
+        // Compute the diff and apply changes
+        const currentIds = new Set(Object.keys(currentState))
+        const nextIds = new Set(Object.keys(nextState))
+
+        // Remove files that are no longer in state
+        for (const fileId of currentIds) {
+          if (!nextIds.has(fileId)) {
+            commitRemove(fileId)
+          }
+        }
+
+        // Upsert files that are new or changed
+        for (const [fileId, state] of Object.entries(nextState)) {
+          const existing = currentState[fileId]
+          // Check if the state actually changed
+          if (
+            !existing ||
+            existing.path !== state.path ||
+            existing.localHash !== state.localHash ||
+            existing.downloadStatus !== state.downloadStatus ||
+            existing.uploadStatus !== state.uploadStatus ||
+            existing.lastSyncError !== state.lastSyncError
+          ) {
+            commitUpsert(fileId, state)
+          }
+        }
+      })
 
     return {
       setFileState,

--- a/packages/core/src/services/local-file-state/LocalFileStateManager.ts
+++ b/packages/core/src/services/local-file-state/LocalFileStateManager.ts
@@ -119,7 +119,7 @@ export class LocalFileStateManager extends Context.Tag("LocalFileStateManager")<
 export const makeLocalFileStateManager = (
   deps: LiveStoreDeps
 ): Effect.Effect<LocalFileStateManagerService> =>
-  Effect.gen(function*() {
+  Effect.sync(() => {
     const { schema, store } = deps
     const { events, queryDb, tables } = schema
 
@@ -186,8 +186,7 @@ export const makeLocalFileStateManager = (
     const setFileState = (
       fileId: string,
       state: LocalFileState
-    ): Effect.Effect<void> =>
-      Effect.sync(() => commitUpsert(fileId, state))
+    ): Effect.Effect<void> => Effect.sync(() => commitUpsert(fileId, state))
 
     // Update transfer status for a file
     const setTransferStatus = (
@@ -199,10 +198,9 @@ export const makeLocalFileStateManager = (
         const existing = readFileState(fileId)
         if (!existing) return // No-op if file doesn't exist
 
-        const updatedState: LocalFileState =
-          action === "upload"
-            ? { ...existing, uploadStatus: status }
-            : { ...existing, downloadStatus: status }
+        const updatedState: LocalFileState = action === "upload"
+          ? { ...existing, uploadStatus: status }
+          : { ...existing, downloadStatus: status }
 
         commitUpsert(fileId, updatedState)
       })
@@ -218,17 +216,15 @@ export const makeLocalFileStateManager = (
         const existing = readFileState(fileId)
         if (!existing) return // No-op if file doesn't exist
 
-        const updatedState: LocalFileState =
-          action === "upload"
-            ? { ...existing, uploadStatus: status, lastSyncError: error }
-            : { ...existing, downloadStatus: status, lastSyncError: error }
+        const updatedState: LocalFileState = action === "upload"
+          ? { ...existing, uploadStatus: status, lastSyncError: error }
+          : { ...existing, downloadStatus: status, lastSyncError: error }
 
         commitUpsert(fileId, updatedState)
       })
 
     // Remove a file's state
-    const removeFile = (fileId: string): Effect.Effect<void> =>
-      Effect.sync(() => commitRemove(fileId))
+    const removeFile = (fileId: string): Effect.Effect<void> => Effect.sync(() => commitRemove(fileId))
 
     // Merge files into state
     const mergeFiles = (patch: LocalFilesState): Effect.Effect<void> =>
@@ -260,8 +256,7 @@ export const makeLocalFileStateManager = (
       })
 
     // Get current state (read-only)
-    const getState = (): Effect.Effect<LocalFilesState> =>
-      Effect.sync(readState)
+    const getState = (): Effect.Effect<LocalFilesState> => Effect.sync(readState)
 
     // Apply a custom updater function
     const atomicUpdate = (

--- a/packages/core/src/services/remote-file-storage/RemoteStorage.ts
+++ b/packages/core/src/services/remote-file-storage/RemoteStorage.ts
@@ -164,7 +164,7 @@ export const makeS3SignerRemoteStorage = (config: RemoteStorageConfig): RemoteSt
     const headers: Record<string, string> = {
       ...config.headers
     }
-    const token = typeof config.authToken === 'function' ? config.authToken() : config.authToken
+    const token = typeof config.authToken === "function" ? config.authToken() : config.authToken
     if (token) {
       headers["Authorization"] = `Bearer ${token}`
     }

--- a/packages/core/src/services/sync-executor/index.ts
+++ b/packages/core/src/services/sync-executor/index.ts
@@ -11,6 +11,7 @@ export {
   SyncExecutor,
   type SyncExecutorConfig,
   type SyncExecutorService,
+  type TaskCompleteCallback,
   type TransferHandler,
   type TransferKind,
   type TransferResult,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -131,6 +131,12 @@ export type FileSyncEvent =
   | { readonly type: "upload:progress"; readonly fileId: string; readonly progress: TransferProgress }
   | { readonly type: "upload:complete"; readonly fileId: string }
   | { readonly type: "upload:error"; readonly fileId: string; readonly error: unknown }
+  | {
+    readonly type: "transfer:exhausted"
+    readonly kind: "upload" | "download"
+    readonly fileId: string
+    readonly error: unknown
+  }
   | { readonly type: "online" }
   | { readonly type: "offline" }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -18,6 +18,7 @@ import type {
   FileSyncTables,
   FileUpdatedPayloadSchema,
   LocalFilesStateSchema,
+  LocalFileStateRowSchema,
   LocalFileStateSchema,
   TransferStatusSchema
 } from "../schema/index.js"
@@ -40,6 +41,11 @@ export type LocalFileState = typeof LocalFileStateSchema.Type
  * Local file state - mutable variant for internal sync operations
  */
 export type LocalFileStateMutable = Schema.Schema.Type<ReturnType<typeof Schema.mutable<typeof LocalFileStateSchema>>>
+
+/**
+ * Local file state row - includes fileId, used for SQLite table operations
+ */
+export type LocalFileStateRow = typeof LocalFileStateRowSchema.Type
 
 /**
  * Map of file IDs to local file states (readonly)

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -315,8 +315,12 @@ export interface FileDisplayState {
  * @example
  * ```typescript
  * // In a React component
- * const [localFileState] = store.useClientDocument(tables.localFileState)
- * const displayState = getFileDisplayState(file, localFileState?.localFiles ?? {})
+ * import { rowsToLocalFilesState } from '@livestore-filesync/core'
+ * import { queryDb } from '@livestore/livestore'
+ *
+ * const rows = store.useQuery(queryDb(tables.localFileState.select()))
+ * const localFilesState = useMemo(() => rowsToLocalFilesState(rows), [rows])
+ * const displayState = getFileDisplayState(file, localFilesState)
  *
  * return displayState.canDisplay
  *   ? <img src={`/${file.path}`} />
@@ -324,7 +328,7 @@ export interface FileDisplayState {
  * ```
  *
  * @param file - The file record from the files table
- * @param localFilesState - The local files state map from the client document
+ * @param localFilesState - The local files state map (use rowsToLocalFilesState to convert query results)
  * @returns The display state for the file
  */
 export function getFileDisplayState(

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/expo",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "license": "MIT",
   "description": "Expo filesystem and image processing adapters for livestore-filesync",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/expo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "license": "MIT",
   "description": "Expo filesystem and image processing adapters for livestore-filesync",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/expo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "license": "MIT",
   "description": "Expo filesystem and image processing adapters for livestore-filesync",

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -151,6 +151,7 @@ Generate multiple thumbnail sizes in the background using a Web Worker.
 ```typescript
 import { createFileSyncSchema } from '@livestore-filesync/core/schema'
 import { createThumbnailSchema } from '@livestore-filesync/image/thumbnails/schema'
+import { State } from '@livestore/livestore'
 
 const fileSyncSchema = createFileSyncSchema()
 const thumbnailSchema = createThumbnailSchema()
@@ -159,6 +160,16 @@ const tables = {
   ...fileSyncSchema.tables,
   ...thumbnailSchema.tables,
 }
+
+const events = {
+  ...fileSyncSchema.events,
+  ...thumbnailSchema.events,
+}
+
+const materializers = State.SQLite.materializers(events, {
+  ...fileSyncSchema.createMaterializers(tables),
+  ...thumbnailSchema.createMaterializers(tables),
+})
 ```
 
 2. **Create a worker file:**

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/image",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "license": "MIT",
   "description": "Image preprocessing and thumbnail generation for livestore-filesync using wasm-vips",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/image",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "license": "MIT",
   "description": "Image preprocessing and thumbnail generation for livestore-filesync using wasm-vips",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/image",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "license": "MIT",
   "description": "Image preprocessing and thumbnail generation for livestore-filesync using wasm-vips",

--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -130,7 +130,7 @@ export type {
   ThumbnailGenerationStatus,
   ThumbnailSizes,
   ThumbnailSizeState,
-  ThumbnailStateDocument,
+  ThumbnailStateRow,
   ThumbnailWorkerRequest,
   ThumbnailWorkerResponse
 } from "./thumbnails/types/index.js"

--- a/packages/image/src/thumbnails/index.ts
+++ b/packages/image/src/thumbnails/index.ts
@@ -96,7 +96,7 @@ export {
 } from "./api/singleton.js"
 
 // Utilities
-export { rowsToThumbnailFilesState } from "./utils/index.js"
+export { parseThumbnailSizes } from "./utils/index.js"
 
 // Worker setup - for creating custom worker entry points
 export { setupThumbnailWorker } from "./worker-core.js"

--- a/packages/image/src/thumbnails/index.ts
+++ b/packages/image/src/thumbnails/index.ts
@@ -95,5 +95,8 @@ export {
   stopThumbnails
 } from "./api/singleton.js"
 
+// Utilities
+export { rowsToThumbnailFilesState } from "./utils/index.js"
+
 // Worker setup - for creating custom worker entry points
 export { setupThumbnailWorker } from "./worker-core.js"

--- a/packages/image/src/thumbnails/index.ts
+++ b/packages/image/src/thumbnails/index.ts
@@ -44,7 +44,7 @@ export type {
   ThumbnailQualitySettings,
   ThumbnailSizes,
   ThumbnailSizeState,
-  ThumbnailStateDocument,
+  ThumbnailStateRow,
   ThumbnailWorkerRequest,
   ThumbnailWorkerResponse
 } from "./types/index.js"

--- a/packages/image/src/thumbnails/schema/index.ts
+++ b/packages/image/src/thumbnails/schema/index.ts
@@ -4,6 +4,13 @@
  * This module exports the schema components needed for thumbnail generation.
  * Applications should merge these with their existing schema.
  *
+ * ARCHITECTURE NOTE: thumbnailState uses a regular SQLite table with
+ * clientOnly events instead of a clientDocument with Schema.Record.
+ * This prevents rebase conflicts during concurrent tab operations by
+ * storing each file's thumbnail state as a separate row rather than a
+ * single JSON blob containing all files.
+ * See: https://github.com/livestorejs/livestore/issues/998
+ *
  * @example
  * ```typescript
  * import { createFileSyncSchema } from '@livestore-filesync/core/schema'
@@ -19,14 +26,15 @@
  * }
  *
  * const materializers = State.SQLite.materializers(events, {
- *   ...fileSyncSchema.createMaterializers(tables)
+ *   ...fileSyncSchema.createMaterializers(tables),
+ *   ...thumbnailSchema.createMaterializers(thumbnailSchema.tables)
  * })
  * ```
  *
  * @module
  */
 
-import { Schema, SessionIdSymbol, State } from "@livestore/livestore"
+import { Events, Schema, State } from "@livestore/livestore"
 
 // ============================================
 // Schema Definitions (Source of Truth)
@@ -56,6 +64,7 @@ export const ThumbnailSizeStateSchema = Schema.Struct({
 
 /**
  * State for all thumbnail sizes of a single file
+ * Note: sizes is stored as JSON in the database row
  */
 export const FileThumbnailStateSchema = Schema.Struct({
   fileId: Schema.String,
@@ -69,6 +78,7 @@ export const FileThumbnailStateSchema = Schema.Struct({
 
 /**
  * Map of file IDs to thumbnail states
+ * Kept for backwards compatibility with consumers.
  */
 export const ThumbnailFilesStateSchema = Schema.Record({
   key: Schema.String,
@@ -89,22 +99,37 @@ export const StoredConfigSchema = Schema.Struct({
 })
 
 /**
- * Root thumbnail state document schema
+ * Row schema for thumbnail state table - stored as JSON for the sizes field
  */
-export const ThumbnailStateDocumentSchema = Schema.Struct({
-  /** Stored config to detect changes */
-  config: Schema.optional(StoredConfigSchema),
-  files: ThumbnailFilesStateSchema
+export const ThumbnailStateRowSchema = Schema.Struct({
+  fileId: Schema.String,
+  contentHash: Schema.String,
+  mimeType: Schema.String,
+  sizesJson: Schema.String // JSON-encoded sizes object
 })
+
+/**
+ * Config row schema for thumbnail config table
+ */
+export const ThumbnailConfigRowSchema = Schema.Struct({
+  id: Schema.String,
+  configHash: Schema.String,
+  sizesJson: Schema.String // JSON-encoded sizes definition
+})
+
+// Type helpers
+type ThumbnailStateRow = typeof ThumbnailStateRowSchema.Type
+type ThumbnailConfigRow = typeof ThumbnailConfigRowSchema.Type
 
 // ============================================
 // Schema Factory
 // ============================================
 
 /**
- * Creates thumbnail schema components (tables)
+ * Creates thumbnail schema components (tables, events, materializers)
  *
- * The thumbnail state is stored in a client document because:
+ * The thumbnail state is stored in SQLite tables because:
+ * - Each file's state is a separate row (avoids Schema.Record rebase conflicts)
  * - Thumbnails are not synced between clients (each generates locally)
  * - State persists across page refreshes
  * - We can show generation progress in UI
@@ -119,31 +144,90 @@ export const ThumbnailStateDocumentSchema = Schema.Struct({
  */
 export function createThumbnailSchema() {
   const tables = {
-    thumbnailState: State.SQLite.clientDocument({
+    /**
+     * Thumbnail state table - stores generation status for each file as individual rows.
+     * The 'sizes' field is stored as JSON since its structure is dynamic based on config.
+     */
+    thumbnailState: State.SQLite.table({
       name: "thumbnailState",
-      schema: ThumbnailStateDocumentSchema,
-      default: {
-        id: SessionIdSymbol,
-        value: {
-          files: {}
-        }
+      columns: {
+        fileId: State.SQLite.text({ primaryKey: true }),
+        contentHash: State.SQLite.text({ default: "" }),
+        mimeType: State.SQLite.text({ default: "" }),
+        sizesJson: State.SQLite.text({ default: "{}" }) // JSON-encoded sizes object
+      }
+    }),
+    /**
+     * Thumbnail config table - stores the current config hash and size definitions.
+     * Single row, rarely changes.
+     */
+    thumbnailConfig: State.SQLite.table({
+      name: "thumbnailConfig",
+      columns: {
+        id: State.SQLite.text({ primaryKey: true }),
+        configHash: State.SQLite.text({ default: "" }),
+        sizesJson: State.SQLite.text({ default: "{}" }) // JSON-encoded sizes definition
       }
     })
   }
 
   const events = {
-    thumbnailStateSet: tables.thumbnailState.set
+    // Thumbnail file state events
+    thumbnailStateUpsert: Events.clientOnly({
+      name: "v1.ThumbnailStateUpsert",
+      schema: ThumbnailStateRowSchema
+    }),
+    thumbnailStateRemove: Events.clientOnly({
+      name: "v1.ThumbnailStateRemove",
+      schema: Schema.Struct({ fileId: Schema.String })
+    }),
+    thumbnailStateClear: Events.clientOnly({
+      name: "v1.ThumbnailStateClear",
+      schema: Schema.Struct({})
+    }),
+
+    // Thumbnail config events
+    thumbnailConfigSet: Events.clientOnly({
+      name: "v1.ThumbnailConfigSet",
+      schema: ThumbnailConfigRowSchema
+    })
   }
+
+  // Create materializers function
+  const createMaterializers = <T extends typeof tables>(appTables: T) => ({
+    "v1.ThumbnailStateUpsert": ({
+      contentHash,
+      fileId,
+      mimeType,
+      sizesJson
+    }: ThumbnailStateRow) => [
+      appTables.thumbnailState.delete().where({ fileId }),
+      appTables.thumbnailState.insert({ fileId, contentHash, mimeType, sizesJson })
+    ],
+    "v1.ThumbnailStateRemove": ({ fileId }: { fileId: string }) => appTables.thumbnailState.delete().where({ fileId }),
+    "v1.ThumbnailStateClear": () => appTables.thumbnailState.delete(),
+    "v1.ThumbnailConfigSet": ({
+      configHash,
+      id,
+      sizesJson
+    }: ThumbnailConfigRow) => [
+      appTables.thumbnailConfig.delete().where({ id }),
+      appTables.thumbnailConfig.insert({ id, configHash, sizesJson })
+    ]
+  })
 
   return {
     tables,
     events,
+    createMaterializers,
     schemas: {
       ThumbnailGenerationStatusSchema,
       ThumbnailSizeStateSchema,
       FileThumbnailStateSchema,
       ThumbnailFilesStateSchema,
-      ThumbnailStateDocumentSchema
+      StoredConfigSchema,
+      ThumbnailStateRowSchema,
+      ThumbnailConfigRowSchema
     }
   }
 }
@@ -161,3 +245,8 @@ export type ThumbnailSchema = ReturnType<typeof createThumbnailSchema>
  * Thumbnail tables type
  */
 export type ThumbnailTables = ThumbnailSchema["tables"]
+
+/**
+ * Thumbnail events type
+ */
+export type ThumbnailEvents = ThumbnailSchema["events"]

--- a/packages/image/src/thumbnails/types/index.ts
+++ b/packages/image/src/thumbnails/types/index.ts
@@ -13,7 +13,7 @@ import type {
   ThumbnailGenerationStatusSchema,
   ThumbnailSchema,
   ThumbnailSizeStateSchema,
-  ThumbnailStateDocumentSchema
+  ThumbnailStateRowSchema
 } from "../schema/index.js"
 
 // ============================================
@@ -48,9 +48,9 @@ export type FileThumbnailState = typeof FileThumbnailStateSchema.Type
 export type ThumbnailFilesState = typeof ThumbnailFilesStateSchema.Type
 
 /**
- * Root thumbnail state document
+ * Row type for thumbnail state table
  */
-export type ThumbnailStateDocument = typeof ThumbnailStateDocumentSchema.Type
+export type ThumbnailStateRow = typeof ThumbnailStateRowSchema.Type
 
 /**
  * Thumbnail tables type
@@ -199,11 +199,6 @@ export type ThumbnailWorkerResponse =
 export type ThumbnailWorkerRequest = ThumbnailGenerateRequest
 
 /**
- * A queryDb function from the app's schema
- */
-export type QueryDbFn = (query: any) => any
-
-/**
  * Files table type (from @livestore-filesync/core)
  */
 export interface FilesTable {
@@ -310,12 +305,6 @@ export interface InitThumbnailsConfig {
    * ```
    */
   schema?: { tables: TablesWithFiles }
-
-  /**
-   * @deprecated Use `schema: { tables }` instead for simpler configuration.
-   * The queryDb function from livestore.
-   */
-  queryDb?: QueryDbFn
 
   /**
    * @deprecated Use `schema: { tables }` instead for simpler configuration.

--- a/packages/image/src/thumbnails/utils/index.ts
+++ b/packages/image/src/thumbnails/utils/index.ts
@@ -4,4 +4,50 @@
  * @module
  */
 
+import type { FileThumbnailState, ThumbnailFilesState, ThumbnailSizeState } from "../types/index.js"
+
 export { isSupportedImageMimeType, SUPPORTED_IMAGE_MIME_TYPES } from "../types/index.js"
+
+/**
+ * Parse the sizesJson string from a thumbnailState row into a typed record.
+ */
+const parseSizesJson = (sizesJson: string): Record<string, ThumbnailSizeState> => {
+  try {
+    return JSON.parse(sizesJson) as Record<string, ThumbnailSizeState>
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Convert an array of thumbnailState table rows into a ThumbnailFilesState map.
+ *
+ * Use this when reading the thumbnailState SQLite table (which returns rows)
+ * and you need the map format keyed by fileId with parsed `sizes`.
+ *
+ * @example
+ * ```typescript
+ * // React
+ * const rows = store.useQuery(queryDb(tables.thumbnailState.select()))
+ * const thumbnailFiles = useMemo(() => rowsToThumbnailFilesState(rows), [rows])
+ * const status = thumbnailFiles[fileId]?.sizes?.['small']?.status ?? 'pending'
+ *
+ * // Vue
+ * const rows = useQuery(queryDb(tables.thumbnailState.select()))
+ * const thumbnailFiles = computed(() => rowsToThumbnailFilesState(rows.value))
+ * ```
+ */
+export function rowsToThumbnailFilesState(
+  rows: ReadonlyArray<{ readonly fileId: string; readonly sizesJson?: string; readonly [key: string]: unknown }>
+): ThumbnailFilesState {
+  const map: Record<string, FileThumbnailState> = {}
+  for (const row of rows) {
+    map[row.fileId] = {
+      fileId: row.fileId,
+      contentHash: (row.contentHash as string) ?? "",
+      mimeType: (row.mimeType as string) ?? "",
+      sizes: parseSizesJson(row.sizesJson ?? "{}")
+    }
+  }
+  return map
+}

--- a/packages/image/test/schema.test.ts
+++ b/packages/image/test/schema.test.ts
@@ -14,7 +14,10 @@ describe("Thumbnail Schema", () => {
       const schema = createThumbnailSchema()
 
       expect(schema.events).toBeDefined()
-      expect(schema.events.thumbnailStateSet).toBeDefined()
+      expect(schema.events.thumbnailStateUpsert).toBeDefined()
+      expect(schema.events.thumbnailStateRemove).toBeDefined()
+      expect(schema.events.thumbnailStateClear).toBeDefined()
+      expect(schema.events.thumbnailConfigSet).toBeDefined()
     })
 
     it("should create schema with schemas export", () => {
@@ -25,7 +28,8 @@ describe("Thumbnail Schema", () => {
       expect(schema.schemas.ThumbnailSizeStateSchema).toBeDefined()
       expect(schema.schemas.FileThumbnailStateSchema).toBeDefined()
       expect(schema.schemas.ThumbnailFilesStateSchema).toBeDefined()
-      expect(schema.schemas.ThumbnailStateDocumentSchema).toBeDefined()
+      expect(schema.schemas.ThumbnailStateRowSchema).toBeDefined()
+      expect(schema.schemas.ThumbnailConfigRowSchema).toBeDefined()
     })
 
     it("should create functional independent schema instances", () => {

--- a/packages/image/test/singleton-api.test.ts
+++ b/packages/image/test/singleton-api.test.ts
@@ -1,0 +1,68 @@
+import { FileSystem } from "@effect/platform/FileSystem"
+import { Layer } from "effect"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { disposeThumbnails, initThumbnails } from "../src/thumbnails/api/singleton.js"
+
+const {
+  createThumbnailsMock,
+  disposeMock,
+  startMock,
+  stopMock
+} = vi.hoisted(() => ({
+  createThumbnailsMock: vi.fn(),
+  disposeMock: vi.fn(async () => undefined),
+  startMock: vi.fn(),
+  stopMock: vi.fn()
+}))
+
+vi.mock("../src/thumbnails/api/createThumbnails.js", () => ({
+  createThumbnails: createThumbnailsMock
+}))
+
+describe("thumbnail singleton API", () => {
+  beforeEach(async () => {
+    createThumbnailsMock.mockReset()
+    disposeMock.mockClear()
+    startMock.mockClear()
+    stopMock.mockClear()
+
+    createThumbnailsMock.mockReturnValue({
+      dispose: disposeMock,
+      getThumbnailState: vi.fn(() => null),
+      regenerate: vi.fn(async () => undefined),
+      resolveThumbnailOrFileUrl: vi.fn(async () => null),
+      resolveThumbnailUrl: vi.fn(async () => null),
+      start: startMock,
+      stop: stopMock
+    })
+
+    await disposeThumbnails()
+  })
+
+  it("initializes with schema tables and no external queryDb", async () => {
+    const filesTable = {
+      select: vi.fn(() => ({ type: "select" })),
+      where: vi.fn(() => ({ type: "where" }))
+    }
+    const fileSystem = Layer.succeed(FileSystem, {} as any)
+
+    const dispose = initThumbnails(
+      { schema: { state: { sqlite: { tables: new Map() } } } } as any,
+      {
+        fileSystem,
+        schema: { tables: { files: filesTable } },
+        sizes: { small: 128 },
+        workerUrl: "/thumbnail.worker.js"
+      }
+    )
+
+    const call = createThumbnailsMock.mock.calls[0]?.[0]
+
+    expect(call).toBeDefined()
+    expect(call.filesTable).toBe(filesTable)
+    expect(call).not.toHaveProperty("queryDb")
+    expect(startMock).toHaveBeenCalledTimes(1)
+
+    await dispose()
+  })
+})

--- a/packages/image/test/thumbnail-service-querydb.test.ts
+++ b/packages/image/test/thumbnail-service-querydb.test.ts
@@ -1,0 +1,131 @@
+import { FileSystem } from "@effect/platform/FileSystem"
+import type * as LiveStoreModule from "@livestore/livestore"
+import { Effect, Layer } from "effect"
+import { describe, expect, it, vi } from "vitest"
+import { createThumbnailSchema } from "../src/thumbnails/schema/index.js"
+import { LocalThumbnailStorage } from "../src/thumbnails/services/LocalThumbnailStorage.js"
+import { makeThumbnailService } from "../src/thumbnails/services/ThumbnailService.js"
+import { ThumbnailWorkerClient } from "../src/thumbnails/services/ThumbnailWorkerClient.js"
+
+const { queryDbMock } = vi.hoisted(() => ({
+  queryDbMock: vi.fn((query: unknown) => query)
+}))
+
+vi.mock("@livestore/livestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof LiveStoreModule>()
+  return {
+    ...actual,
+    queryDb: queryDbMock
+  }
+})
+
+const makeService = async ({
+  filesTable,
+  store
+}: {
+  filesTable: { select: () => unknown; where: (conditions: unknown) => unknown }
+  store: { commit: (event: unknown) => void; query: (query: unknown) => unknown }
+}) => {
+  const thumbnailSchema = createThumbnailSchema()
+
+  const workerClientLayer = Layer.succeed(ThumbnailWorkerClient, {
+    generate: () => Effect.succeed({ thumbnails: [] }),
+    isReady: () => Effect.succeed(true),
+    terminate: () => Effect.succeed(undefined),
+    waitForReady: () => Effect.succeed(undefined)
+  } as any)
+
+  const storageLayer = Layer.succeed(LocalThumbnailStorage, {
+    deleteThumbnails: () => Effect.succeed(undefined),
+    getThumbnailPath: () => "thumbnails/mock.webp",
+    getThumbnailUrl: () => Effect.succeed("blob:mock"),
+    readThumbnail: () => Effect.succeed(new Uint8Array()),
+    thumbnailExists: () => Effect.succeed(false),
+    writeThumbnail: () => Effect.succeed("thumbnails/mock.webp")
+  } as any)
+
+  const fileSystemLayer = Layer.succeed(FileSystem, {
+    exists: () => Effect.succeed(false),
+    readFile: () => Effect.succeed(new Uint8Array())
+  } as any)
+
+  return Effect.runPromise(
+    makeThumbnailService(store as any, thumbnailSchema.tables, thumbnailSchema.events, {
+      concurrency: 1,
+      filesTable: filesTable as any,
+      format: "webp",
+      pollInterval: 0,
+      sizes: { small: 128 },
+      supportedMimeTypes: ["image/jpeg", "image/png", "image/webp"]
+    }).pipe(Effect.provide(Layer.mergeAll(workerClientLayer, storageLayer, fileSystemLayer)))
+  )
+}
+
+describe("ThumbnailService query behavior", () => {
+  it("scans files on start when filesTable is present without external queryDb", async () => {
+    queryDbMock.mockClear()
+
+    const selectQuery = { kind: "files.select" }
+    const filesTable = {
+      select: vi.fn(() => selectQuery),
+      where: vi.fn()
+    }
+
+    const store = {
+      commit: vi.fn(),
+      query: vi
+        .fn<(query: unknown) => unknown>()
+        // readConfig()
+        .mockReturnValueOnce([])
+        // scanExistingFiles() -> files table
+        .mockReturnValueOnce([])
+    }
+
+    const service = await makeService({ filesTable, store })
+    await Effect.runPromise(service.start())
+
+    expect(filesTable.select).toHaveBeenCalledTimes(1)
+    expect(queryDbMock).toHaveBeenCalledWith(selectQuery)
+    expect(store.query).toHaveBeenCalledWith(selectQuery)
+
+    await Effect.runPromise(service.stop())
+  })
+
+  it("regenerate queries files table and queues work without external queryDb", async () => {
+    queryDbMock.mockClear()
+
+    const whereQuery = { kind: "files.where" }
+    const filesTable = {
+      select: vi.fn(),
+      where: vi.fn(() => whereQuery)
+    }
+
+    const store = {
+      commit: vi.fn(),
+      query: vi
+        .fn<(query: unknown) => unknown>(() => [])
+        // regenerate() -> files table lookup
+        .mockReturnValueOnce([
+          {
+            contentHash: "content-hash",
+            deletedAt: null,
+            id: "file-1",
+            path: "photo.jpg",
+            remoteKey: "remote-key"
+          }
+        ])
+        // regenerate() -> readFileThumbnailState(fileId)
+        .mockReturnValueOnce([])
+        // queueFile() -> readFileThumbnailState(file.id)
+        .mockReturnValueOnce([])
+    }
+
+    const service = await makeService({ filesTable, store })
+    await Effect.runPromise(service.regenerate("file-1"))
+
+    expect(filesTable.where).toHaveBeenCalledWith({ id: "file-1" })
+    expect(queryDbMock).toHaveBeenCalledWith(whereQuery)
+    expect(store.query).toHaveBeenCalledWith(whereQuery)
+    expect(store.commit).toHaveBeenCalled()
+  })
+})

--- a/packages/opfs/package.json
+++ b/packages/opfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/opfs",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "license": "MIT",
   "description": "OPFS filesystem adapter for livestore-filesync",

--- a/packages/opfs/package.json
+++ b/packages/opfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/opfs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "license": "MIT",
   "description": "OPFS filesystem adapter for livestore-filesync",

--- a/packages/opfs/package.json
+++ b/packages/opfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/opfs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "license": "MIT",
   "description": "OPFS filesystem adapter for livestore-filesync",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/r2",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "license": "MIT",
   "description": "Cloudflare R2 storage adapter for livestore-filesync with Worker utilities",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/r2",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "license": "MIT",
   "description": "Cloudflare R2 storage adapter for livestore-filesync with Worker utilities",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/r2",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "license": "MIT",
   "description": "Cloudflare R2 storage adapter for livestore-filesync with Worker utilities",

--- a/packages/s3-signer/package.json
+++ b/packages/s3-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/s3-signer",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "license": "MIT",
   "description": "S3-compatible signing service for livestore-filesync (Cloudflare Workers)",

--- a/packages/s3-signer/package.json
+++ b/packages/s3-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/s3-signer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "license": "MIT",
   "description": "S3-compatible signing service for livestore-filesync (Cloudflare Workers)",

--- a/packages/s3-signer/package.json
+++ b/packages/s3-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/s3-signer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "license": "MIT",
   "description": "S3-compatible signing service for livestore-filesync (Cloudflare Workers)",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-tests",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "private": true,
   "description": "Framework-agnostic E2E tests for livestore-filesync",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-tests",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "type": "module",
   "private": true,
   "description": "Framework-agnostic E2E tests for livestore-filesync",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-tests",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "private": true,
   "description": "Framework-agnostic E2E tests for livestore-filesync",

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
 // Select framework via E2E_FRAMEWORK env var (default: vue)
-const framework = process.env.E2E_FRAMEWORK || 'vue'
+const framework = process.env.E2E_FRAMEWORK || 'react'
 
 const frameworkConfig: Record<string, { cwd: string; port: number; testMatch?: string }> = {
   vue: {


### PR DESCRIPTION
## Summary

Systematic stability and reliability improvements to the sync engine, addressing error handling, race conditions, and observability gaps identified through deep codebase analysis.

- **10 targeted fixes**, each with its own commit and tests
- **164 tests passing** (up from 135 on `dev`)
- All type checks and linting pass

## Fixes

### Error Handling (5 fixes)
1. **Event callback safety** — `emit()` wraps each subscriber callback in try/catch so one bad listener can't crash the sync engine or block other subscribers
2. **Typed preprocessor errors** — `Effect.tryPromise` for preprocessors produces `StorageError` instead of fiber-crashing defects
3. **Per-event batch error handling** — Each event in a batch is individually wrapped; a failure in event 3/5 no longer replays events 1-2 or stalls the cursor
4. **goOffline preserves error states** — Only resets `inProgress` transfers to `queued`; files that failed for non-network reasons (corrupt, too large) are no longer infinitely retried
5. **start() failure visibility** — `createFileSync.start()` emits `sync:error` with `context: "start"` when initialization fails

### Race Conditions & Edge Cases (3 fixes)
6. **Atomic enqueue deduplication** — `Ref.modify` instead of `Ref.get` + `Ref.update` prevents concurrent fibers from double-enqueuing the same file
7. **Interrupt in-flight on leadership loss** — `stopSyncLoop()` now interrupts running transfer fibers via `interruptInflight()` and resets their status from `inProgress` → `queued`
8. **Cancel downloads on deleteFile** — `deleteFile()` calls `cancelDownload()` to prevent a queued download from writing the file back after deletion

### Observability & Validation (2 fixes)
9. **Log/emit on retry exhaustion** — New `transfer:exhausted` event and `Effect.logWarning` when all retries are used up (previously silent)
10. **Signer response validation** — Runtime validation of upload/download signer JSON responses instead of blind `as` casts

## New APIs

| API | Location | Description |
|-----|----------|-------------|
| `transfer:exhausted` event | `FileSyncEvent` type | Emitted when a transfer fails after all retries |
| `onTaskComplete` callback | `makeSyncExecutor()` | Called after each task completes (success or failure) |
| `interruptInflight()` | `SyncExecutorService` | Interrupts all running transfer fibers, returns metadata |
| `TaskCompleteCallback` type | `sync-executor/index.ts` | Type for the completion callback |

## Files Changed

- `packages/core/src/services/sync-executor/SyncExecutor.ts` — Fiber tracking, `interruptInflight`, `onTaskComplete`, atomic deduplication
- `packages/core/src/services/file-sync/FileSync.ts` — Per-event error handling, emit safety, goOffline fix, deleteFile cancel, leadership transition
- `packages/core/src/services/remote-file-storage/RemoteStorage.ts` — Signer response validation
- `packages/core/src/api/createFileSync.ts` — sync:error on start failure
- `packages/core/src/types/index.ts` — `transfer:exhausted` event type
- `docs/STABILITY.md` — Full documentation of all 10 fixes
- `docs/ARCHITECTURE.md` — Updated error events table and monitoring examples