### PR TITLE
Add local-only FileSync mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Use the tasks/ folder for persistent implementation plans. Documents in this fol
 
 Use the docs/ folder for up to date documentation. If we change any aspects relating to documents in this folder make sure to keep the docs updated.
 
+The React examples are the maintained examples. The Vue examples are historical and are not actively maintained unless a task explicitly requests Vue work.
+
  made thAfter completed a task always:
 - Make sure docs are updated to reflect and relevant changes (README.md and docs/ files)
 - Ensure tests pass (pnpm test)

--- a/README.md
+++ b/README.md
@@ -106,10 +106,9 @@ const url = await resolveFileUrl(result.fileId)
 
 See `examples/` for complete implementations:
 - `examples/react-filesync` — React example
-- `examples/vue-filesync` — Vue example
-- `examples/vue-thumbnail` — Vue example with image thumbnail generation (wasm-vips)
 - `examples/react-thumbnail` — React example with image thumbnails using the canvas processor (no WASM)
 - `examples/node-filesync` — Node.js usage
+- `examples/vue-filesync` and `examples/vue-thumbnail` — historical Vue examples; these are not actively maintained
 
 **Note on examples**: I've been using examples to test out the implementation on different platforms and frameworks. The examples are also used to run the e2e tests against which makes them more complicated than they need to be for testing and debugging purposes. As the project matures the examples will probably migrate towards a few simpler examples and the e2e testing targets into seperate apps.
 
@@ -288,6 +287,15 @@ const preprocessors: PreprocessorMap = {
     // Your transformation logic
     return transformedFile
   },
+  // Or return metadata with the final file
+  'image/webp': async (file) => ({
+    file,
+    metadata: {
+      mimeType: file.type,
+      sizeBytes: file.size,
+      image: { width: 1200, height: 800 }
+    }
+  }),
   // Or specific types
   'image/png': async (file) => convertPngToJpeg(file)
 }
@@ -307,6 +315,27 @@ Preprocessor patterns support:
 - **Universal wildcard**: `'*'` or `'*/*'` matches any file
 
 Priority order: exact match > wildcard subtype > universal wildcard.
+
+### File Metadata
+
+Preprocessors can return `{ file, metadata }` to persist metadata on the synced `files` row. Metadata is stored with the current `contentHash`, so `updateFile()` replaces it when file content changes.
+
+```typescript
+import { getFileMetadata } from '@livestore-filesync/core'
+
+const metadata = getFileMetadata(fileRecord)
+const ratio = metadata?.image
+  ? `${metadata.image.width} / ${metadata.image.height}`
+  : undefined
+```
+
+Supported metadata fields are:
+- `mimeType?: string`
+- `sizeBytes?: number`
+- `image?: { width: number; height: number }`
+- `custom?: Record<string, unknown>`
+
+Existing preprocessors that return only `File` continue to work. Existing rows without metadata read as `null` through `getFileMetadata()`.
 
 ### Image Preprocessing Package
 
@@ -333,6 +362,8 @@ initFileSync(store, {
   }
 })
 ```
+
+Image preprocessors return metadata for the final output image, including MIME type, byte size, and pixel dimensions. When an image is already in the target format and is returned unchanged, dimensions are still extracted once so UIs can reserve layout before `resolveFileUrl()` returns.
 
 **Lightweight Canvas Alternative:** If you don't need the full power of wasm-vips (ICC profile preservation, lossless compression), you can use the canvas-based processor:
 
@@ -399,7 +430,7 @@ const dispose = initThumbnails(store, {
 const url = await resolveThumbnailUrl(fileId, 'small')
 ```
 
-See `examples/vue-thumbnail` (wasm-vips) and `examples/react-thumbnail` (canvas processor) for complete implementations.
+See `examples/react-thumbnail` for the maintained thumbnail example. Vue thumbnail examples are historical and are not actively maintained.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ const dispose = initFileSync(store, {
 // await dispose()
 ```
 
+For unauthenticated/local-first use, pass `remote: false`. Files are stored and resolved locally,
+and FileSync will not call the signer API or enqueue uploads/downloads:
+
+```typescript
+const dispose = initFileSync(store, {
+  fileSystem: opfsLayer(),
+  remote: false
+})
+```
+
 ### 3. Use the API
 
 ```typescript
@@ -135,6 +145,11 @@ createFileSync({ fileSystem: NodeFileSystem.layer, ... })
 ```
 
 ## Backend Storage
+
+Backend storage is optional. Use `remote: false` for local-only apps or guest sessions where files
+should be saved, read, updated, and deleted only from local storage. In local-only mode, `remoteKey`
+stays as an empty string and `localFileState` reports local files as `uploadStatus: "done"` and
+`downloadStatus: "done"`.
 
 The client expects a **signer service** running in a server-side process that mints short-lived URLs for uploads/downloads and handles deletes. In the examples, we leverage the existing LiveStore Cloudflare Worker to host this signer service alongside LiveStore sync — see the `src/cf-worker/` folder in each example for the implementation.
 
@@ -215,6 +230,9 @@ const url = await resolveFileUrl(file.id)
 
 **Automatic prioritization:** When `resolveFileUrl()` is called for a file that's queued for download, that file is automatically moved to the front of the queue. This ensures visible files are downloaded before background files.
 
+In local-only mode, `resolveFileUrl()` only resolves local files and returns `null` if the local
+bytes are missing; it never signs a remote download URL.
+
 See `examples/react-filesync` or `examples/vue-filesync` for complete implementations.
 
 ## Handling Upload State
@@ -264,7 +282,8 @@ No configuration required — this works automatically.
 - Mid-session restarts (`syncNow()`, heartbeat recovery) restart `eventsStream` from the stored
   cursor and do **not** rescan every file row.
 - `syncNow()` re-enqueues files already marked as `queued` in `localFileState` before restarting
-  the stream, so pending work resumes without a full bootstrap.
+  the stream, so pending work resumes without a full bootstrap. In local-only mode this is harmless
+  and does not enqueue remote transfers.
 - Internal `localFileState` diff updates are batched into a single `store.commit(...)` call when
   possible, reducing per-file event bursts during reconciliation.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,7 +37,8 @@ The services are wired together as Effect layers inside `createFileSync` and the
 
 FileSync supports file preprocessing via MIME-type based preprocessors. When a file is saved or
 updated, the system checks if a preprocessor is configured for that file's MIME type and applies
-the transformation before storing.
+the transformation before storing. Preprocessors may return either a `File` or
+`{ file, metadata }`; metadata is synced on the `files` row as `metadataJson`.
 
 ### How Preprocessors Work
 
@@ -59,13 +60,16 @@ the transformation before storing.
          +-----+-----+
                |
                v
+[Normalize file + metadata]
+               |
+               v
 [Hash processed file]
                |
                v
 [Write to local storage]
                |
                v
-[Create file record]
+[Create/update file record with metadataJson]
                |
                v
 [Queue for upload]
@@ -92,17 +96,43 @@ initFileSync(store, {
   options: {
     preprocessors: {
       'image/*': async (file) => resizeImage(file, { maxDimension: 1500 }),
+      'image/webp': async (file) => ({
+        file,
+        metadata: {
+          mimeType: file.type,
+          sizeBytes: file.size,
+          image: { width: 1200, height: 800 }
+        }
+      }),
       'video/mp4': async (file) => compressVideo(file)
     }
   }
 })
 ```
 
+### File Metadata
+
+File metadata is stored on the synced `files` table as `metadataJson`, nullable for older rows and for preprocessors that return only `File`. Use `getFileMetadata(fileRecord)` or `parseFileMetadata(metadataJson)` from core instead of parsing this column in app code.
+
+The built-in metadata shape is intentionally small:
+
+```typescript
+type FileMetadata = {
+  mimeType?: string
+  sizeBytes?: number
+  image?: { width: number; height: number }
+  custom?: Record<string, unknown>
+}
+```
+
+Metadata belongs to the row's current `contentHash`. `saveFile()` persists metadata with `v1.FileCreated`; content-changing `updateFile()` persists replacement metadata with `v1.FileUpdated`; remote-key-only updates preserve existing metadata. Existing synced update events that omit the metadata field also preserve existing metadata.
+
 ### Implementation Notes
 
 - Preprocessors run synchronously in the main thread by default
 - For heavy processing (e.g., video), consider using Web Workers
 - The preprocessed file is what gets hashed and stored (both locally and remotely)
+- Preprocessor metadata describes the final stored file, not the original input
 - Preprocessing errors will cause the `saveFile` operation to fail
 
 ## FileSystem requirement

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,8 @@ The services are wired together as Effect layers inside `createFileSync` and the
   The built-in implementation is signer-backed and targets S3-compatible object storage via a signer
   API (`GET /health`, `POST /v1/sign/upload`, `POST /v1/sign/download`, `POST /v1/delete`) that mints
   short-lived URLs. Alternative backends are still possible by supplying a custom `RemoteStorageAdapter`.
+  When `remote: false` is configured, FileSync uses an internal disabled adapter and the orchestration
+  layer avoids remote calls entirely.
 
 - `SyncExecutor` (internal): manages upload/download queues with concurrency limits and retry/backoff logic.
   Worker fibers are tracked and can be restarted via `ensureWorkers()` if they exit unexpectedly.
@@ -31,7 +33,20 @@ The services are wired together as Effect layers inside `createFileSync` and the
 - `FileSync`: orchestration service and primary CRUD API. Tracks online state, consumes the
   LiveStore event stream for file events, updates local state incrementally, schedules transfers
   through `SyncExecutor`, updates remote URLs, and runs health checks. It also handles `saveFile`,
-  `updateFile`, `deleteFile`, and `resolveFileUrl`, always writing locally first.
+  `updateFile`, `deleteFile`, and `resolveFileUrl`, always writing locally first. In local-only mode
+  it still writes and resolves local files, but skips health checks and upload/download/delete work.
+
+## Remote Modes
+
+FileSync has two explicit remote modes:
+
+- **Remote-backed**: the default mode. `initFileSync` uses `/api` when `remote` is omitted, and
+  `createFileSync` requires a signer config. Empty `remoteKey` means the local file should upload;
+  remote keys allow other clients to download.
+- **Local-only**: enabled with `remote: false`. `saveFile()` and `updateFile()` keep `remoteKey` as
+  `""`, write `localFileState` as `uploadStatus: "done"` and `downloadStatus: "done"` when local
+  bytes exist, and never calls `/health`, `/v1/sign/upload`, `/v1/sign/download`, or `/v1/delete`.
+  `triggerSync()` and `retryErrors()` are no-ops/harmless for remote transfers in this mode.
 
 ## File Preprocessors
 
@@ -152,6 +167,15 @@ initFileSync(store, {
 })
 ```
 
+Local-only usage for guest/unauthenticated sessions:
+
+```typescript
+initFileSync(store, {
+  fileSystem: opfsLayer(),
+  remote: false
+})
+```
+
 ### Node.js usage
 
 ```typescript
@@ -187,6 +211,8 @@ Text diagram (arrows show the main direction of calls):
 Notes:
 - `FileSync` is the primary entry point for CRUD; it writes locally first and the leader event stream queues sync.
 - `FileSync` handles background uploads/downloads and keeps metadata in the LiveStore tables.
+- With `remote: false`, the `SyncExecutor` and `RemoteStorage` transfer path is disabled for file
+  records and local state remains stable without queued/error upload states.
 - `LocalFileStorage` is the only layer that touches the filesystem adapter directly.
 - `RemoteStorage` is the only layer that knows about the remote backend API.
 

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -2,6 +2,10 @@
 
 This document describes the stability and self-healing mechanisms implemented in FileSync to ensure robust operation in production environments.
 
+These mechanisms apply to remote-backed FileSync unless noted otherwise. When FileSync is initialized
+with `remote: false`, remote transfer queues and signer health checks are disabled; `syncNow()` and
+`retryErrors()` remain safe but do not enqueue uploads or downloads.
+
 ## Recent Feature Implementations
 
 ### 1. Stale Transfer Recovery Gating
@@ -46,6 +50,9 @@ initFileSync(store, {
 ```
 
 **Heartbeat checks (leader-only):**
+
+Heartbeat transfer checks are skipped in local-only mode because no remote transfer workers or queues
+are started.
 
 1. **Event stream liveness**: If the stream fiber is dead (null ref or exited), it is restarted via `startEventStream()`.
 

--- a/docs/image-processing.md
+++ b/docs/image-processing.md
@@ -30,6 +30,8 @@ const preprocessor = createImagePreprocessor({
 })
 ```
 
+Image preprocessors return the processed file together with metadata for the final stored image. This includes the final MIME type, byte size, and pixel dimensions. If a file is returned unchanged because it is already within bounds or below the size threshold, dimensions are still extracted once when the runtime supports image decoding.
+
 **Requirements:**
 - Copy `node_modules/wasm-vips/lib/vips.wasm` to your public directory
 - ~3MB WASM download on first use (cached by browser)
@@ -56,6 +58,21 @@ const preprocessor = createImagePreprocessor({
 - Converts all images to sRGB (loses wide-gamut colors)
 - No lossless WebP support
 - Strips all metadata (EXIF, etc.)
+
+### Using Synced Image Metadata
+
+FileSync stores preprocessor metadata on the synced `files` row. Apps can use it to reserve layout before `resolveFileUrl()` or thumbnail URLs are ready:
+
+```typescript
+import { getFileMetadata } from '@livestore-filesync/core'
+
+const metadata = getFileMetadata(file)
+const style = metadata?.image
+  ? { aspectRatio: `${metadata.image.width} / ${metadata.image.height}` }
+  : undefined
+```
+
+The metadata describes the final output image after resizing and format conversion, not the original input image.
 
 ## Thumbnail Workers
 

--- a/examples/node-filesync/package.json
+++ b/examples/node-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-node-example",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/examples/react-filesync/package.json
+++ b/examples/react-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-example",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-filesync/package.json
+++ b/examples/react-filesync/package.json
@@ -20,6 +20,7 @@
     "@effect/typeclass": "catalog:",
     "@effect/workflow": "catalog:",
     "@livestore-filesync/core": "workspace:*",
+    "@livestore-filesync/image": "workspace:*",
     "@livestore-filesync/opfs": "workspace:*",
     "@livestore-filesync/r2": "workspace:*",
     "@livestore-filesync/s3-signer": "workspace:*",

--- a/examples/react-filesync/src/App.tsx
+++ b/examples/react-filesync/src/App.tsx
@@ -5,7 +5,7 @@ import { useState } from "react"
 import { FileSyncProvider } from "./components/FileSyncProvider.tsx"
 import { Gallery } from "./components/Gallery.tsx"
 import { SyncStatus } from "./components/SyncStatus.tsx"
-import { authToken, getAuthHeaders, healthCheckIntervalMs } from "./livestore/store.ts"
+import { authToken, getAuthHeaders, healthCheckIntervalMs, localOnlyFileSync } from "./livestore/store.ts"
 
 export const App = () => {
   const [storeRegistry] = useState(() => new StoreRegistry())
@@ -16,6 +16,7 @@ export const App = () => {
         authHeaders={getAuthHeaders}
         authToken={authToken}
         healthCheckIntervalMs={healthCheckIntervalMs}
+        localOnly={localOnlyFileSync}
       >
         <div className="app-layout">
           <div className="main">

--- a/examples/react-filesync/src/components/FileSyncProvider.tsx
+++ b/examples/react-filesync/src/components/FileSyncProvider.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from "../livestore/store.ts"
 
 type FileSyncProviderProps = {
   signerBaseUrl?: string
+  localOnly?: boolean
   headers?: Record<string, string>
   authHeaders?: () => Record<string, string>
   authToken?: string
@@ -19,6 +20,7 @@ const FileSyncProviderInner = ({
   children,
   headers,
   healthCheckIntervalMs,
+  localOnly = false,
   signerBaseUrl = "/api"
 }: FileSyncProviderProps) => {
   const store = useAppStore()
@@ -28,11 +30,13 @@ const FileSyncProviderInner = ({
     const resolvedHeaders = headers ?? authHeaders?.()
     const dispose = initFileSync(store, {
       fileSystem: opfsLayer(),
-      remote: {
-        signerBaseUrl,
-        ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
-        ...(authToken ? { authToken } : {})
-      },
+      remote: localOnly
+        ? false
+        : {
+          signerBaseUrl,
+          ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
+          ...(authToken ? { authToken } : {})
+        },
       options: {
         ...(healthCheckIntervalMs !== undefined ? { healthCheckIntervalMs } : {}),
         preprocessors: {
@@ -55,7 +59,7 @@ const FileSyncProviderInner = ({
       window.clearTimeout(retryQueuedTransfers)
       void dispose()
     }
-  }, [store, signerBaseUrl, headers, authHeaders, authToken, healthCheckIntervalMs])
+  }, [store, signerBaseUrl, headers, authHeaders, authToken, healthCheckIntervalMs, localOnly])
 
   return ready ? <>{children}</> : null
 }

--- a/examples/react-filesync/src/components/FileSyncProvider.tsx
+++ b/examples/react-filesync/src/components/FileSyncProvider.tsx
@@ -1,4 +1,5 @@
 import { initFileSync, triggerSync } from "@livestore-filesync/core"
+import { createImagePreprocessor } from "@livestore-filesync/image/preprocessor"
 import { layer as opfsLayer } from "@livestore-filesync/opfs"
 import { type ReactNode, Suspense, useEffect, useState } from "react"
 import { useAppStore } from "../livestore/store.ts"
@@ -32,7 +33,17 @@ const FileSyncProviderInner = ({
         ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
         ...(authToken ? { authToken } : {})
       },
-      ...(healthCheckIntervalMs !== undefined ? { options: { healthCheckIntervalMs } } : {})
+      options: {
+        ...(healthCheckIntervalMs !== undefined ? { healthCheckIntervalMs } : {}),
+        preprocessors: {
+          "image/*": createImagePreprocessor({
+            processor: "canvas",
+            maxDimension: 1500,
+            quality: 90,
+            format: "jpeg"
+          })
+        }
+      }
     })
 
     // Mark as ready on next tick to ensure initFileSync has fully completed

--- a/examples/react-filesync/src/components/ImageCard.tsx
+++ b/examples/react-filesync/src/components/ImageCard.tsx
@@ -1,4 +1,11 @@
-import { deleteFile, getFileDisplayState, readFile, resolveFileUrl, updateFile } from "@livestore-filesync/core"
+import {
+  deleteFile,
+  getFileDisplayState,
+  getFileMetadata,
+  readFile,
+  resolveFileUrl,
+  updateFile
+} from "@livestore-filesync/core"
 import { queryDb } from "@livestore/livestore"
 import React, { useEffect, useState } from "react"
 import { tables } from "../livestore/schema.ts"
@@ -14,15 +21,36 @@ export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
   )
   const displayState = getFileDisplayState(file, localFileState ?? undefined)
   const { canDisplay, isUploading, localState: localFile } = displayState
+  const metadata = getFileMetadata(file)
+  const imageAspectRatio = metadata?.image
+    ? `${metadata.image.width} / ${metadata.image.height}`
+    : undefined
 
   const [src, setSrc] = useState<string | null>(null)
 
   // Resolve file URL on mount and when file updates
   useEffect(() => {
-    resolveFileUrl(file.id).then((url) => {
-      if (url) setSrc(url)
-    })
-  }, [file.id, file.updatedAt])
+    let cancelled = false
+
+    resolveFileUrl(file.id)
+      .then((url) => {
+        if (!cancelled) setSrc(url)
+      })
+      .catch(() => {
+        if (!cancelled) setSrc(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    file.id,
+    file.updatedAt,
+    file.remoteKey,
+    localFile?.downloadStatus,
+    localFile?.localHash,
+    localFile?.uploadStatus
+  ])
 
   const handleDelete = async () => {
     try {
@@ -44,7 +72,7 @@ export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
 
   return (
     <div className="card" data-testid="file-card">
-      <div className="image-container">
+      <div className="image-container" style={{ aspectRatio: imageAspectRatio }}>
         {canDisplay && src ?
           (
             <img
@@ -56,7 +84,7 @@ export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
           ) :
           (
             <div className="image-placeholder" data-testid="file-placeholder">
-              {isUploading ? "Uploading..." : "Waiting for file..."}
+              <span className="sr-only">{isUploading ? "Uploading image" : "Image pending"}</span>
             </div>
           )}
       </div>
@@ -99,6 +127,12 @@ export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
             <tr>
               <td className="label">File: Hash</td>
               <td>{file.contentHash}</td>
+            </tr>
+            <tr>
+              <td className="label">File: Metadata</td>
+              <td data-testid="file-metadata">
+                {metadata?.image ? `${metadata.image.width}x${metadata.image.height}` : "None"}
+              </td>
             </tr>
             <tr>
               <td className="label">File: Updated At</td>

--- a/examples/react-filesync/src/index.css
+++ b/examples/react-filesync/src/index.css
@@ -68,7 +68,8 @@
 
 .image-container {
   position: relative;
-  min-height: 200px;
+  aspect-ratio: 1 / 1;
+  min-height: 120px;
   background: #eee;
   border-right: 1px solid #ccc;
   align-self: stretch;
@@ -85,11 +86,33 @@
 .image-placeholder {
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #666;
-  font-size: 0.875rem;
+  background:
+    linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.5), transparent),
+    #eee;
+  background-size: 220% 100%;
+  animation: placeholder-shimmer 1.4s ease-in-out infinite;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes placeholder-shimmer {
+  from {
+    background-position: 220% 0;
+  }
+
+  to {
+    background-position: -220% 0;
+  }
 }
 
 .info {

--- a/examples/react-filesync/src/livestore/store.ts
+++ b/examples/react-filesync/src/livestore/store.ts
@@ -14,6 +14,8 @@ export const healthCheckIntervalMs = urlParams.get("healthCheckIntervalMs")
   ? Number(urlParams.get("healthCheckIntervalMs"))
   : undefined
 
+export const localOnlyFileSync = urlParams.get("localOnly") === "1"
+
 const adapter = makePersistedAdapter({
   storage: { type: "opfs" },
   worker: LiveStoreWorker,

--- a/examples/react-thumbnail/package.json
+++ b/examples/react-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-react-thumbnail-example",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/react-thumbnail/src/components/FileSyncImage.tsx
+++ b/examples/react-thumbnail/src/components/FileSyncImage.tsx
@@ -57,31 +57,38 @@ export const FileSyncImage: React.FC<FileSyncImageProps> = ({
     let cancelled = false
 
     const resolveUrl = async () => {
-      // If requesting full size, use file URL directly
-      if (selectedSize === "full") {
+      try {
+        // If requesting full size, use file URL directly
+        if (selectedSize === "full") {
+          const url = await resolveFileUrl(fileId)
+          if (!cancelled) {
+            setSrc(url)
+            setIsUsingThumbnail(false)
+          }
+          return
+        }
+
+        // Try thumbnail first if it's ready
+        if (thumbnailStatus === "done") {
+          const thumbnailUrl = await resolveThumbnailUrl(fileId, selectedSize)
+          if (!cancelled && thumbnailUrl) {
+            setSrc(thumbnailUrl)
+            setIsUsingThumbnail(true)
+            return
+          }
+        }
+
+        // Fallback to full image
         const url = await resolveFileUrl(fileId)
-        if (!cancelled && url) {
+        if (!cancelled) {
           setSrc(url)
           setIsUsingThumbnail(false)
         }
-        return
-      }
-
-      // Try thumbnail first if it's ready
-      if (thumbnailStatus === "done") {
-        const thumbnailUrl = await resolveThumbnailUrl(fileId, selectedSize)
-        if (!cancelled && thumbnailUrl) {
-          setSrc(thumbnailUrl)
-          setIsUsingThumbnail(true)
-          return
+      } catch {
+        if (!cancelled) {
+          setSrc(null)
+          setIsUsingThumbnail(false)
         }
-      }
-
-      // Fallback to full image
-      const url = await resolveFileUrl(fileId)
-      if (!cancelled && url) {
-        setSrc(url)
-        setIsUsingThumbnail(false)
       }
     }
 
@@ -90,7 +97,16 @@ export const FileSyncImage: React.FC<FileSyncImageProps> = ({
     return () => {
       cancelled = true
     }
-  }, [fileId, selectedSize, thumbnailStatus, file?.updatedAt])
+  }, [
+    fileId,
+    selectedSize,
+    thumbnailStatus,
+    file?.updatedAt,
+    file?.remoteKey,
+    localFileState?.downloadStatus,
+    localFileState?.localHash,
+    localFileState?.uploadStatus
+  ])
 
   // Show placeholder if not displayable or no src
   if (!canDisplay || !src) {
@@ -98,8 +114,8 @@ export const FileSyncImage: React.FC<FileSyncImageProps> = ({
       <div
         className={`image-placeholder ${className ?? ""}`}
         data-testid="file-placeholder"
+        aria-label={isUploading ? "Uploading image" : "Image pending"}
       >
-        {isUploading ? "Uploading..." : "Waiting for file..."}
       </div>
     )
   }

--- a/examples/react-thumbnail/src/components/FileSyncProvider.tsx
+++ b/examples/react-thumbnail/src/components/FileSyncProvider.tsx
@@ -1,4 +1,5 @@
 import { initFileSync } from "@livestore-filesync/core"
+import { createImagePreprocessor } from "@livestore-filesync/image/preprocessor"
 import { initThumbnails, type ThumbnailFormat, type ThumbnailSizes } from "@livestore-filesync/image/thumbnails"
 import { layer as opfsLayer } from "@livestore-filesync/opfs"
 import { useStore } from "@livestore/react"
@@ -39,6 +40,16 @@ const FileSyncProviderInner = ({
         signerBaseUrl,
         ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
         ...(authToken ? { authToken } : {})
+      },
+      options: {
+        preprocessors: {
+          "image/*": createImagePreprocessor({
+            processor: "canvas",
+            maxDimension: 1500,
+            quality: 90,
+            format: "jpeg"
+          })
+        }
       }
     })
 

--- a/examples/react-thumbnail/src/components/ImageCard.tsx
+++ b/examples/react-thumbnail/src/components/ImageCard.tsx
@@ -1,4 +1,4 @@
-import { deleteFile, getFileDisplayState, readFile, updateFile } from "@livestore-filesync/core"
+import { deleteFile, getFileDisplayState, getFileMetadata, readFile, updateFile } from "@livestore-filesync/core"
 import { parseThumbnailSizes } from "@livestore-filesync/image/thumbnails"
 import { queryDb } from "@livestore/livestore"
 import { useStore } from "@livestore/react"
@@ -17,6 +17,10 @@ export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
   )
   const displayState = getFileDisplayState(file, localFileState ?? undefined)
   const { canDisplay, localState: localFile } = displayState
+  const metadata = getFileMetadata(file)
+  const imageAspectRatio = metadata?.image
+    ? `${metadata.image.width} / ${metadata.image.height}`
+    : undefined
 
   // Per-file thumbnail query
   const thumbRow = store.useQuery(
@@ -46,7 +50,7 @@ export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
 
   return (
     <div className="card" data-testid="file-card">
-      <div className="image-container">
+      <div className="image-container" style={{ aspectRatio: imageAspectRatio }}>
         <FileSyncImage
           fileId={file.id}
           fillMode="cover"
@@ -100,6 +104,12 @@ export const ImageCard: React.FC<{ file: FileType }> = ({ file }) => {
             <tr>
               <td className="label">File: Hash</td>
               <td>{file.contentHash}</td>
+            </tr>
+            <tr>
+              <td className="label">File: Metadata</td>
+              <td data-testid="file-metadata">
+                {metadata?.image ? `${metadata.image.width}x${metadata.image.height}` : "None"}
+              </td>
             </tr>
             <tr>
               <td className="label">Local File: Upload</td>

--- a/examples/react-thumbnail/src/index.css
+++ b/examples/react-thumbnail/src/index.css
@@ -82,7 +82,8 @@ body {
 
 .image-container {
   position: relative;
-  min-height: 200px;
+  aspect-ratio: 1 / 1;
+  min-height: 120px;
   background: #eee;
   border-right: 1px solid #ccc;
   align-self: stretch;
@@ -99,11 +100,33 @@ body {
 .image-placeholder {
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #666;
-  font-size: 0.875rem;
+  background:
+    linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.5), transparent),
+    #eee;
+  background-size: 220% 100%;
+  animation: placeholder-shimmer 1.4s ease-in-out infinite;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes placeholder-shimmer {
+  from {
+    background-position: 220% 0;
+  }
+
+  to {
+    background-position: -220% 0;
+  }
 }
 
 .thumbnail-badge {

--- a/examples/vue-filesync/package.json
+++ b/examples/vue-filesync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-example",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/examples/vue-thumbnail/package.json
+++ b/examples/vue-thumbnail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livestore-filesync-vue-thumbnail-example",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/core",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "Framework-agnostic file syncing for LiveStore applications with OPFS support",

--- a/packages/core/src/api/createFileSync.ts
+++ b/packages/core/src/api/createFileSync.ts
@@ -3,7 +3,7 @@
  *
  * Creates a file sync instance that handles:
  * - Local file storage (OPFS)
- * - Remote file sync (upload/download)
+ * - Remote file sync (upload/download), unless explicitly configured local-only
  * - Offline support with automatic retry
  * - Two-pass reconciliation for efficient syncing
  *
@@ -20,6 +20,7 @@ import {
   HashServiceLive,
   LocalFileStorage,
   LocalFileStorageLive,
+  makeLocalOnlyRemoteStorage,
   makeS3SignerRemoteStorage,
   RemoteStorage
 } from "../services/index.js"
@@ -69,6 +70,16 @@ export type SyncEvent = FileSyncEvent
 
 export type { SyncSchema, SyncStore } from "../livestore/types.js"
 
+export interface SignerRemoteConfig {
+  signerBaseUrl: string
+  headers?: Record<string, string>
+  authToken?: string
+  /** Include credentials (cookies) in cross-origin requests. Required for cookie-based auth. */
+  includeCredentials?: boolean
+}
+
+export type FileSyncRemoteConfig = SignerRemoteConfig | false
+
 /**
  * Configuration for createFileSync
  */
@@ -79,14 +90,8 @@ export interface CreateFileSyncConfig {
   /** Schema with tables and events from createFileSyncSchema */
   schema: SyncSchema
 
-  /** Remote storage configuration */
-  remote: {
-    signerBaseUrl: string
-    headers?: Record<string, string>
-    authToken?: string
-    /** Include credentials (cookies) in cross-origin requests. Required for cookie-based auth. */
-    includeCredentials?: boolean
-  }
+  /** Remote storage configuration. Pass false for explicit local-only mode. */
+  remote: FileSyncRemoteConfig
 
   /** FileSystem layer - required. Use @livestore-filesync/opfs for browsers or @effect/platform-node for Node. */
   fileSystem: Layer.Layer<FileSystem>
@@ -206,6 +211,14 @@ export interface FileSyncInstance {
  *   remote: { signerBaseUrl: '/api' }
  * })
  *
+ * // Local-only / unauthenticated mode
+ * const localOnlyFileSync = createFileSync({
+ *   store,
+ *   schema: { tables, events, queryDb },
+ *   fileSystem: opfsLayer(),
+ *   remote: false
+ * })
+ *
  * // Node.js (using platform-node)
  * import { NodeFileSystem } from '@effect/platform-node'
  *
@@ -228,6 +241,7 @@ export interface FileSyncInstance {
  */
 export function createFileSync(config: CreateFileSyncConfig): FileSyncInstance {
   const { fileSystem, hashService, options = {}, remote, schema, store } = config
+  const isLocalOnly = remote === false
 
   // State
   let online = true // optimistic default; health check will correct if offline
@@ -244,19 +258,22 @@ export function createFileSync(config: CreateFileSyncConfig): FileSyncInstance {
     ...(options.localPathRoot !== undefined ? { localPathRoot: options.localPathRoot } : {})
   }
 
-  const remoteStorageConfig: RemoteStorageConfig = {
-    signerBaseUrl: remote.signerBaseUrl,
-    ...(remote.headers ? { headers: remote.headers } : {}),
-    ...(remote.authToken ? { authToken: remote.authToken } : {}),
-    ...(remote.includeCredentials ? { includeCredentials: remote.includeCredentials } : {})
-  }
-
   const RemoteStorageLive = Layer.succeed(
     RemoteStorage,
-    makeS3SignerRemoteStorage(remoteStorageConfig)
+    isLocalOnly
+      ? makeLocalOnlyRemoteStorage()
+      : makeS3SignerRemoteStorage(
+        {
+          signerBaseUrl: remote.signerBaseUrl,
+          ...(remote.headers ? { headers: remote.headers } : {}),
+          ...(remote.authToken ? { authToken: remote.authToken } : {}),
+          ...(remote.includeCredentials ? { includeCredentials: remote.includeCredentials } : {})
+        } satisfies RemoteStorageConfig
+      )
   )
 
   const fileSyncConfig: FileSyncConfig = {
+    remoteMode: isLocalOnly ? "local-only" : "remote",
     executorConfig: {
       maxConcurrentDownloads: options.maxConcurrentDownloads ?? defaultExecutorConfig.maxConcurrentDownloads,
       maxConcurrentUploads: options.maxConcurrentUploads ?? defaultExecutorConfig.maxConcurrentUploads

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -11,6 +11,8 @@ export {
   createFileSync,
   type CreateFileSyncConfig,
   type FileSyncInstance,
+  type FileSyncRemoteConfig,
+  type SignerRemoteConfig,
   type SyncEvent,
   type SyncFileOperationResult,
   type SyncFileRecord,

--- a/packages/core/src/api/singleton.ts
+++ b/packages/core/src/api/singleton.ts
@@ -14,7 +14,12 @@ import type { SyncSchema } from "../livestore/types.js"
 import { createFileSyncSchema } from "../schema/index.js"
 import type { Hash } from "../services/hash/index.js"
 import type { FileSyncEvent } from "../types/index.js"
-import { createFileSync, type CreateFileSyncConfig, type FileSyncInstance } from "./createFileSync.js"
+import {
+  createFileSync,
+  type CreateFileSyncConfig,
+  type FileSyncInstance,
+  type SignerRemoteConfig
+} from "./createFileSync.js"
 
 const DEFAULT_SIGNER_BASE_URL = "/api"
 const REQUIRED_TABLES = ["files", "localFileState"] as const
@@ -42,13 +47,8 @@ export interface InitFileSyncConfig {
    */
   hashService?: Layer.Layer<Hash>
 
-  remote?: {
-    signerBaseUrl?: string
-    headers?: Record<string, string>
-    authToken?: string
-    /** Include credentials (cookies) in cross-origin requests. Required for cookie-based auth. */
-    includeCredentials?: boolean
-  }
+  /** Remote signer config. Pass false for explicit local-only mode. */
+  remote?: false | (Partial<Pick<SignerRemoteConfig, "signerBaseUrl">> & Omit<SignerRemoteConfig, "signerBaseUrl">)
   options?: CreateFileSyncConfig["options"]
   schema?: SchemaFallback
 
@@ -69,6 +69,7 @@ export interface InitFileSyncConfig {
 
 let singleton: FileSyncInstance | null = null
 let singletonUserId: string | null = null
+let singletonRemoteMode: "remote" | "local-only" | null = null
 let singletonRefCount = 0
 
 const retainSingleton = (): () => Promise<void> => {
@@ -85,6 +86,7 @@ const retainSingleton = (): () => Promise<void> => {
     const instance = singleton
     singleton = null
     singletonUserId = null
+    singletonRemoteMode = null
     await instance?.dispose()
   }
 }
@@ -161,6 +163,12 @@ const resolveSchema = (store: Store<any>, schema?: SchemaFallback): SyncSchema =
  *   userId: 'user-123'
  * })
  *
+ * // Local-only / unauthenticated mode
+ * const disposeLocal = initFileSync(store, {
+ *   fileSystem: opfsLayer(),
+ *   remote: false
+ * })
+ *
  * // Later, to clean up:
  * await dispose()
  * ```
@@ -172,13 +180,15 @@ export const initFileSync = (
   config: InitFileSyncConfig
 ): () => Promise<void> => {
   const userId = config.userId ?? null
+  const remoteMode = config.remote === false ? "local-only" : "remote"
 
-  // If singleton exists but for a different user, dispose it first
-  if (singleton && singletonUserId !== userId) {
-    console.log("[FileSync] User changed, disposing old instance")
+  // If singleton exists but for a different user or mode, dispose it first
+  if (singleton && (singletonUserId !== userId || singletonRemoteMode !== remoteMode)) {
+    console.log("[FileSync] User or remote mode changed, disposing old instance")
     singleton.dispose()
     singleton = null
     singletonUserId = null
+    singletonRemoteMode = null
     singletonRefCount = 0
   }
 
@@ -187,6 +197,7 @@ export const initFileSync = (
   }
 
   singletonUserId = userId
+  singletonRemoteMode = remoteMode
 
   if (!config.fileSystem) {
     throw new Error(
@@ -195,12 +206,14 @@ export const initFileSync = (
   }
 
   const schema = resolveSchema(store, config.schema)
-  const remote: CreateFileSyncConfig["remote"] = {
-    signerBaseUrl: config.remote?.signerBaseUrl ?? DEFAULT_SIGNER_BASE_URL,
-    ...(config.remote?.headers ? { headers: config.remote.headers } : {}),
-    ...(config.remote?.authToken ? { authToken: config.remote.authToken } : {}),
-    ...(config.remote?.includeCredentials ? { includeCredentials: config.remote.includeCredentials } : {})
-  }
+  const remote: CreateFileSyncConfig["remote"] = config.remote === false
+    ? false
+    : {
+      signerBaseUrl: config.remote?.signerBaseUrl ?? DEFAULT_SIGNER_BASE_URL,
+      ...(config.remote?.headers ? { headers: config.remote.headers } : {}),
+      ...(config.remote?.authToken ? { authToken: config.remote.authToken } : {}),
+      ...(config.remote?.includeCredentials ? { includeCredentials: config.remote.includeCredentials } : {})
+    }
 
   singleton = createFileSync({
     store,
@@ -245,6 +258,7 @@ export const disposeFileSync = async (): Promise<void> => {
     await singleton.dispose()
     singleton = null
     singletonUserId = null
+    singletonRemoteMode = null
     singletonRefCount = 0
   }
 }

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -97,6 +97,23 @@ export const FileSyncCursorSchema = Schema.Struct({
   updatedAt: Schema.Date
 })
 
+/**
+ * Synced file metadata schema.
+ * Stored as JSON on the files row and associated with that row's contentHash.
+ */
+export const FileMetadataSchema = Schema.Struct({
+  mimeType: Schema.optional(Schema.String),
+  sizeBytes: Schema.optional(Schema.Number),
+  image: Schema.optional(Schema.Struct({
+    width: Schema.Number,
+    height: Schema.Number
+  })),
+  custom: Schema.optional(Schema.Record({
+    key: Schema.String,
+    value: Schema.Unknown
+  }))
+})
+
 // ============================================
 // Event Payload Schemas
 // ============================================
@@ -108,6 +125,7 @@ export const FileCreatedPayloadSchema = Schema.Struct({
   id: Schema.String,
   path: Schema.String,
   contentHash: Schema.String,
+  metadataJson: Schema.optional(Schema.NullOr(Schema.String)),
   createdAt: Schema.Date,
   updatedAt: Schema.Date
 })
@@ -120,6 +138,7 @@ export const FileUpdatedPayloadSchema = Schema.Struct({
   path: Schema.String,
   remoteKey: Schema.String,
   contentHash: Schema.String,
+  metadataJson: Schema.optional(Schema.NullOr(Schema.String)),
   updatedAt: Schema.Date
 })
 
@@ -161,6 +180,7 @@ export function createFileSyncSchema() {
         path: State.SQLite.text({ default: "" }),
         remoteKey: State.SQLite.text({ default: "" }),
         contentHash: State.SQLite.text({ default: "" }),
+        metadataJson: State.SQLite.text({ nullable: true }),
         createdAt: State.SQLite.integer({ schema: Schema.DateFromNumber }),
         updatedAt: State.SQLite.integer({ schema: Schema.DateFromNumber }),
         deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromNumber })
@@ -241,16 +261,33 @@ export function createFileSyncSchema() {
       contentHash,
       createdAt,
       id,
+      metadataJson,
       path,
       updatedAt
-    }: FileCreatedPayload) => appTables.files.insert({ id, path, contentHash, createdAt, updatedAt }),
+    }: FileCreatedPayload) =>
+      appTables.files.insert({
+        id,
+        path,
+        contentHash,
+        metadataJson: metadataJson ?? null,
+        createdAt,
+        updatedAt
+      }),
     "v1.FileUpdated": ({
       contentHash,
       id,
+      metadataJson,
       path,
       remoteKey,
       updatedAt
-    }: FileUpdatedPayload) => appTables.files.update({ path, remoteKey, contentHash, updatedAt }).where({ id }),
+    }: FileUpdatedPayload) =>
+      appTables.files.update({
+        path,
+        remoteKey,
+        contentHash,
+        ...(metadataJson !== undefined ? { metadataJson } : {}),
+        updatedAt
+      }).where({ id }),
     "v1.FileDeleted": ({ deletedAt, id }: FileDeletedPayload) => appTables.files.update({ deletedAt }).where({ id }),
 
     // Local file state materializers - row-level operations
@@ -280,6 +317,7 @@ export function createFileSyncSchema() {
       LocalFileStateRowSchema,
       LocalFilesStateSchema,
       FileSyncCursorSchema,
+      FileMetadataSchema,
       FileCreatedPayloadSchema,
       FileUpdatedPayloadSchema,
       FileDeletedPayloadSchema

--- a/packages/core/src/services/file-sync/FileSync.storage.test.ts
+++ b/packages/core/src/services/file-sync/FileSync.storage.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest"
 import { createTestStore } from "../../../test/helpers/livestore.js"
 import type { FileSyncConfig } from "../../services/file-sync/FileSync.js"
 import { HashServiceLive } from "../../services/hash/index.js"
-import type { PreprocessorMap } from "../../types/index.js"
+import { parseFileMetadata, type PreprocessorMap } from "../../types/index.js"
 import { hashFile, makeStoredPath } from "../../utils/index.js"
 import { stripFilesRoot } from "../../utils/path.js"
 import { LocalFileStateManagerLive } from "../local-file-state/index.js"
@@ -64,6 +64,7 @@ describe("FileSync - File operations", () => {
       expect(files).toHaveLength(1)
       const saved = files[0]!
       expect(saved.path).toBe(makeStoredPath(deps.storeId, saved.contentHash))
+      expect(saved.metadataJson).toBeNull()
 
       const exists = await runtime.runPromise(localStorage.fileExists(saved.path))
       expect(exists).toBe(true)
@@ -255,9 +256,167 @@ describe("FileSync - Preprocessor integration", () => {
       const files = store.query(deps.schema.queryDb(tables.files.select()))
       expect(files).toHaveLength(1)
       expect(files[0]?.contentHash).toBe(expectedHash)
+      expect(files[0]?.metadataJson).toBeNull()
     } finally {
       await runtime.runPromise(Scope.close(scope, Exit.void))
       await runtime.dispose()
+      await shutdown()
+    }
+  })
+
+  it("persists metadata from metadata-capable preprocessor results on saveFile", async () => {
+    const preprocessors: PreprocessorMap = {
+      "image/*": async (file) => ({
+        file: new File([await file.arrayBuffer()], "processed.png", { type: "image/png" }),
+        metadata: {
+          image: { width: 320, height: 180 },
+          custom: { source: "unit-test" }
+        }
+      })
+    }
+
+    const { deps, shutdown, store, tables } = await createTestStore()
+    const runtime = createRuntime(deps, { preprocessors })
+    const fileSync = await runtime.runPromise(Effect.gen(function*() {
+      return yield* FileSync
+    }))
+    const scope = await runtime.runPromise(Scope.make())
+
+    try {
+      const originalFile = new File(["image data"], "test.png", { type: "image/png" })
+      const result = await runtime.runPromise(Scope.extend(fileSync.saveFile(originalFile), scope))
+
+      const files = store.query(deps.schema.queryDb(tables.files.where({ id: result.fileId })))
+      expect(files).toHaveLength(1)
+      expect(parseFileMetadata(files[0]?.metadataJson)).toEqual({
+        mimeType: "image/png",
+        sizeBytes: originalFile.size,
+        image: { width: 320, height: 180 },
+        custom: { source: "unit-test" }
+      })
+    } finally {
+      await runtime.runPromise(Scope.close(scope, Exit.void))
+      await runtime.dispose()
+      await shutdown()
+    }
+  })
+
+  it("replaces metadata on content-changing updateFile and clears it when new content has none", async () => {
+    const preprocessors: PreprocessorMap = {
+      "text/*": async (file) => {
+        const content = await file.text()
+        const processed = new File([`processed: ${content}`], file.name, { type: file.type })
+        if (file.name.startsWith("nometa")) {
+          return processed
+        }
+        return {
+          file: processed,
+          metadata: {
+            mimeType: file.type,
+            image: { width: content.length, height: content.length + 1 },
+            custom: { name: file.name }
+          }
+        }
+      }
+    }
+
+    const { deps, shutdown, store, tables } = await createTestStore()
+    const runtime = createRuntime(deps, { preprocessors })
+    const fileSync = await runtime.runPromise(Effect.gen(function*() {
+      return yield* FileSync
+    }))
+    const scope = await runtime.runPromise(Scope.make())
+
+    try {
+      const saved = await runtime.runPromise(
+        Scope.extend(fileSync.saveFile(new File(["one"], "one.txt", { type: "text/plain" })), scope)
+      )
+      const firstRecord = store.query(deps.schema.queryDb(tables.files.where({ id: saved.fileId })))[0]
+      expect(parseFileMetadata(firstRecord?.metadataJson)?.image).toEqual({ width: 3, height: 4 })
+
+      await runtime.runPromise(
+        Scope.extend(fileSync.updateFile(saved.fileId, new File(["longer"], "two.txt", { type: "text/plain" })), scope)
+      )
+      const secondRecord = store.query(deps.schema.queryDb(tables.files.where({ id: saved.fileId })))[0]
+      expect(parseFileMetadata(secondRecord?.metadataJson)).toMatchObject({
+        image: { width: 6, height: 7 },
+        custom: { name: "two.txt" }
+      })
+
+      await runtime.runPromise(
+        Scope.extend(
+          fileSync.updateFile(saved.fileId, new File(["without"], "nometa.txt", { type: "text/plain" })),
+          scope
+        )
+      )
+      const thirdRecord = store.query(deps.schema.queryDb(tables.files.where({ id: saved.fileId })))[0]
+      expect(thirdRecord?.metadataJson).toBeNull()
+    } finally {
+      await runtime.runPromise(Scope.close(scope, Exit.void))
+      await runtime.dispose()
+      await shutdown()
+    }
+  })
+
+  it("materializes old file events without metadata as null metadata", async () => {
+    const { deps, events, shutdown, store, tables } = await createTestStore()
+    const id = crypto.randomUUID()
+    const path = makeStoredPath(deps.storeId, "old-event-hash")
+
+    try {
+      store.commit(events.fileCreated({
+        id,
+        path,
+        contentHash: "old-event-hash",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }))
+
+      const created = store.query(deps.schema.queryDb(tables.files.where({ id })))[0]
+      expect(created?.metadataJson).toBeNull()
+
+      store.commit(events.fileUpdated({
+        id,
+        path,
+        remoteKey: stripFilesRoot(path),
+        contentHash: "old-event-hash",
+        updatedAt: new Date()
+      }))
+
+      const updated = store.query(deps.schema.queryDb(tables.files.where({ id })))[0]
+      expect(updated?.metadataJson).toBeNull()
+    } finally {
+      await shutdown()
+    }
+  })
+
+  it("preserves existing metadata when old file update events omit metadata", async () => {
+    const { deps, events, shutdown, store, tables } = await createTestStore()
+    const id = crypto.randomUUID()
+    const path = makeStoredPath(deps.storeId, "metadata-hash")
+    const metadataJson = JSON.stringify({ image: { width: 12, height: 8 } })
+
+    try {
+      store.commit(events.fileCreated({
+        id,
+        path,
+        contentHash: "metadata-hash",
+        metadataJson,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }))
+
+      store.commit(events.fileUpdated({
+        id,
+        path,
+        remoteKey: stripFilesRoot(path),
+        contentHash: "metadata-hash",
+        updatedAt: new Date()
+      }))
+
+      const updated = store.query(deps.schema.queryDb(tables.files.where({ id })))[0]
+      expect(updated?.metadataJson).toBe(metadataJson)
+    } finally {
       await shutdown()
     }
   })

--- a/packages/core/src/services/file-sync/FileSync.storage.test.ts
+++ b/packages/core/src/services/file-sync/FileSync.storage.test.ts
@@ -1,6 +1,7 @@
 import { Effect, Exit, Layer, ManagedRuntime, Scope } from "effect"
-import { describe, expect, it } from "vitest"
-import { createTestStore } from "../../../test/helpers/livestore.js"
+import { describe, expect, it, vi } from "vitest"
+import { createTestStore, delay } from "../../../test/helpers/livestore.js"
+import { DeleteError, DownloadError, UploadError } from "../../errors/index.js"
 import type { FileSyncConfig } from "../../services/file-sync/FileSync.js"
 import { HashServiceLive } from "../../services/hash/index.js"
 import { parseFileMetadata, type PreprocessorMap } from "../../types/index.js"
@@ -8,11 +9,25 @@ import { hashFile, makeStoredPath } from "../../utils/index.js"
 import { stripFilesRoot } from "../../utils/path.js"
 import { LocalFileStateManagerLive } from "../local-file-state/index.js"
 import { LocalFileStorage, LocalFileStorageMemory } from "../local-file-storage/index.js"
-import { RemoteStorageMemory } from "../remote-file-storage/index.js"
+import {
+  type DownloadOptions,
+  RemoteStorage,
+  RemoteStorageMemory,
+  type RemoteStorageService,
+  type UploadOptions
+} from "../remote-file-storage/index.js"
 import { FileSync, FileSyncLive } from "./index.js"
 
 const createRuntime = (
   deps: Parameters<typeof FileSyncLive>[0],
+  config?: Partial<FileSyncConfig>
+) => {
+  return createRuntimeWithRemoteStorage(deps, RemoteStorageMemory, config)
+}
+
+const createRuntimeWithRemoteStorage = (
+  deps: Parameters<typeof FileSyncLive>[0],
+  remoteStorageLayer: Layer.Layer<RemoteStorage>,
   config?: Partial<FileSyncConfig>
 ) => {
   const localFileStateManagerLayer = LocalFileStateManagerLive(deps)
@@ -21,7 +36,7 @@ const createRuntime = (
     HashServiceLive,
     LocalFileStorageMemory,
     localFileStateManagerLayer,
-    RemoteStorageMemory
+    remoteStorageLayer
   )
   const fileSyncLayer = Layer.provide(baseLayer)(
     FileSyncLive(deps, {
@@ -38,6 +53,35 @@ const createRuntime = (
   )
   const mainLayer = Layer.mergeAll(baseLayer, fileSyncLayer)
   return ManagedRuntime.make(mainLayer)
+}
+
+const createFailingRemoteStorage = () => {
+  const upload = vi.fn((_: File, _options: UploadOptions) =>
+    Effect.fail(new UploadError({ message: "upload should not be called" }))
+  )
+  const download = vi.fn((_key: string, _options?: DownloadOptions) =>
+    Effect.fail(new DownloadError({ message: "download should not be called", url: _key }))
+  )
+  const deleteFile = vi.fn((_key: string) =>
+    Effect.fail(new DeleteError({ message: "delete should not be called", path: _key }))
+  )
+  const getDownloadUrl = vi.fn((_key: string) =>
+    Effect.fail(new DownloadError({ message: "getDownloadUrl should not be called", url: _key }))
+  )
+  const checkHealth = vi.fn(() => Effect.succeed(true))
+  const service: RemoteStorageService = {
+    upload,
+    download,
+    delete: deleteFile,
+    getDownloadUrl,
+    checkHealth,
+    getConfig: () => ({ mode: "local-only" })
+  }
+
+  return {
+    layer: Layer.succeed(RemoteStorage, service),
+    spies: { upload, download, deleteFile, getDownloadUrl, checkHealth }
+  }
 }
 
 // Helper to run hashFile with the HashService layer
@@ -202,6 +246,149 @@ describe("FileSync - File operations", () => {
       )
       expect(records[0]?.path).toBe(remotePath)
     } finally {
+      await runtime.runPromise(Scope.close(scope, Exit.void))
+      await runtime.dispose()
+      await shutdown()
+    }
+  })
+})
+
+describe("FileSync - Local-only mode", () => {
+  it("saves locally with stable state and no remote calls", async () => {
+    const { deps, shutdown, store, tables } = await createTestStore()
+    const remote = createFailingRemoteStorage()
+    const runtime = createRuntimeWithRemoteStorage(deps, remote.layer, { remoteMode: "local-only" })
+    const fileSync = await runtime.runPromise(Effect.gen(function*() {
+      return yield* FileSync
+    }))
+    const localStorage = await runtime.runPromise(Effect.gen(function*() {
+      return yield* LocalFileStorage
+    }))
+    const scope = await runtime.runPromise(Scope.make())
+
+    try {
+      const result = await runtime.runPromise(
+        Scope.extend(fileSync.saveFile(new File(["guest"], "guest.txt", { type: "text/plain" })), scope)
+      )
+      const url = await runtime.runPromise(Scope.extend(fileSync.resolveFileUrl(result.fileId), scope))
+
+      expect(url?.startsWith("file://")).toBe(true)
+      const storedFile = await runtime.runPromise(localStorage.readFile(result.path))
+      expect(await storedFile.text()).toBe("guest")
+
+      const files = store.query(deps.schema.queryDb(tables.files.where({ id: result.fileId })))
+      expect(files[0]?.remoteKey).toBe("")
+
+      const state = await runtime.runPromise(fileSync.getLocalFilesState())
+      expect(state[result.fileId]).toMatchObject({
+        path: result.path,
+        localHash: result.contentHash,
+        uploadStatus: "done",
+        downloadStatus: "done",
+        lastSyncError: ""
+      })
+
+      expect(remote.spies.upload).not.toHaveBeenCalled()
+      expect(remote.spies.download).not.toHaveBeenCalled()
+      expect(remote.spies.deleteFile).not.toHaveBeenCalled()
+      expect(remote.spies.getDownloadUrl).not.toHaveBeenCalled()
+      expect(remote.spies.checkHealth).not.toHaveBeenCalled()
+    } finally {
+      await runtime.runPromise(Scope.close(scope, Exit.void))
+      await runtime.dispose()
+      await shutdown()
+    }
+  })
+
+  it("updates and deletes locally without remote storage", async () => {
+    const { deps, events, shutdown, store, tables } = await createTestStore()
+    const remote = createFailingRemoteStorage()
+    const runtime = createRuntimeWithRemoteStorage(deps, remote.layer, { remoteMode: "local-only" })
+    const fileSync = await runtime.runPromise(Effect.gen(function*() {
+      return yield* FileSync
+    }))
+    const localStorage = await runtime.runPromise(Effect.gen(function*() {
+      return yield* LocalFileStorage
+    }))
+    const scope = await runtime.runPromise(Scope.make())
+
+    try {
+      const saved = await runtime.runPromise(
+        Scope.extend(fileSync.saveFile(new File(["before"], "guest.txt")), scope)
+      )
+      store.commit(events.fileUpdated({
+        id: saved.fileId,
+        path: saved.path,
+        remoteKey: "stale/remote/key",
+        contentHash: saved.contentHash,
+        updatedAt: new Date()
+      }))
+
+      const updated = await runtime.runPromise(
+        Scope.extend(fileSync.updateFile(saved.fileId, new File(["after"], "guest.txt")), scope)
+      )
+
+      expect(updated.path).not.toBe(saved.path)
+      expect(await runtime.runPromise(localStorage.fileExists(saved.path))).toBe(false)
+      expect(await runtime.runPromise(localStorage.fileExists(updated.path))).toBe(true)
+
+      let files = store.query(deps.schema.queryDb(tables.files.where({ id: saved.fileId })))
+      expect(files[0]?.remoteKey).toBe("")
+
+      let state = await runtime.runPromise(fileSync.getLocalFilesState())
+      expect(state[saved.fileId]).toMatchObject({
+        uploadStatus: "done",
+        downloadStatus: "done",
+        lastSyncError: ""
+      })
+
+      await runtime.runPromise(Scope.extend(fileSync.deleteFile(saved.fileId), scope))
+      files = store.query(deps.schema.queryDb(tables.files.where({ id: saved.fileId })))
+      expect(files[0]?.deletedAt).not.toBeNull()
+      expect(await runtime.runPromise(localStorage.fileExists(updated.path))).toBe(false)
+      state = await runtime.runPromise(fileSync.getLocalFilesState())
+      expect(state[saved.fileId]).toBeUndefined()
+
+      expect(remote.spies.upload).not.toHaveBeenCalled()
+      expect(remote.spies.download).not.toHaveBeenCalled()
+      expect(remote.spies.deleteFile).not.toHaveBeenCalled()
+      expect(remote.spies.getDownloadUrl).not.toHaveBeenCalled()
+      expect(remote.spies.checkHealth).not.toHaveBeenCalled()
+    } finally {
+      await runtime.runPromise(Scope.close(scope, Exit.void))
+      await runtime.dispose()
+      await shutdown()
+    }
+  })
+
+  it("start, syncNow, and retryErrors do not enqueue remote work", async () => {
+    const { deps, shutdown } = await createTestStore()
+    const remote = createFailingRemoteStorage()
+    const runtime = createRuntimeWithRemoteStorage(deps, remote.layer, {
+      healthCheckIntervalMs: 10,
+      heartbeatIntervalMs: 10,
+      remoteMode: "local-only"
+    })
+    const fileSync = await runtime.runPromise(Effect.gen(function*() {
+      return yield* FileSync
+    }))
+    const scope = await runtime.runPromise(Scope.make())
+
+    try {
+      await runtime.runPromise(Scope.extend(fileSync.start(), scope))
+      await runtime.runPromise(Scope.extend(fileSync.syncNow(), scope))
+      const retried = await runtime.runPromise(fileSync.retryErrors())
+      await delay(30)
+
+      expect(retried).toEqual([])
+      expect(await runtime.runPromise(fileSync.isOnline())).toBe(true)
+      expect(remote.spies.upload).not.toHaveBeenCalled()
+      expect(remote.spies.download).not.toHaveBeenCalled()
+      expect(remote.spies.deleteFile).not.toHaveBeenCalled()
+      expect(remote.spies.getDownloadUrl).not.toHaveBeenCalled()
+      expect(remote.spies.checkHealth).not.toHaveBeenCalled()
+    } finally {
+      await runtime.runPromise(fileSync.stop())
       await runtime.runPromise(Scope.close(scope, Exit.void))
       await runtime.dispose()
       await shutdown()

--- a/packages/core/src/services/file-sync/FileSync.ts
+++ b/packages/core/src/services/file-sync/FileSync.ts
@@ -181,6 +181,14 @@ const resolveLocalFileUrl = (root: string | undefined, storedPath: string): stri
  */
 export interface FileSyncConfig {
   /**
+   * File transfer mode.
+   * - "remote": normal signer-backed upload/download/delete behavior
+   * - "local-only": local storage only; no remote calls or transfer queue work
+   * @default "remote"
+   */
+  readonly remoteMode?: "remote" | "local-only"
+
+  /**
    * Sync executor configuration
    */
   readonly executorConfig?: Partial<SyncExecutorConfig>
@@ -283,6 +291,7 @@ export const makeFileSync = (
     const remoteStorage = yield* RemoteStorage
     const { schema, store, storeId } = deps
     const { events, queryDb, tables } = schema
+    const isLocalOnly = config.remoteMode === "local-only"
 
     // Local wrapper for hashFile that uses the captured hash service
     const doHashFile = (file: File) => hashService.hashFile(file)
@@ -477,6 +486,7 @@ export const makeFileSync = (
     // but may not have corresponding entries in the executor queues (e.g. after goOffline reset)
     const reEnqueueQueuedTransfers = (): Effect.Effect<void> =>
       Effect.gen(function*() {
+        if (isLocalOnly) return
         const state = yield* stateManager.getState()
         for (const [fileId, localFile] of Object.entries(state)) {
           if (localFile.uploadStatus === "queued") {
@@ -499,6 +509,7 @@ export const makeFileSync = (
 
     const startHealthCheckLoop = (): Effect.Effect<void> =>
       Effect.gen(function*() {
+        if (isLocalOnly) return
         const existing = yield* Ref.get(healthCheckFiberRef)
         if (existing) return
 
@@ -543,6 +554,7 @@ export const makeFileSync = (
     // The transfer may have failed for legitimate reasons (e.g. bad file) while backend is still reachable.
     const checkConnectivityOnFailure = (): Effect.Effect<void> =>
       Effect.gen(function*() {
+        if (isLocalOnly) return
         const isHealthy = yield* remoteStorage.checkHealth()
         if (!isHealthy) {
           yield* goOffline()
@@ -852,6 +864,19 @@ export const makeFileSync = (
         }
       })
 
+    const setLocalOnlyAvailableFileState = (
+      fileId: string,
+      path: string,
+      localHash: string
+    ): Effect.Effect<void> =>
+      stateManager.setFileState(fileId, {
+        path,
+        localHash,
+        uploadStatus: "done",
+        downloadStatus: "done",
+        lastSyncError: ""
+      })
+
     const readLocalHash = (path: string) =>
       Effect.gen(function*() {
         const exists = yield* localStorage.fileExists(path)
@@ -871,6 +896,11 @@ export const makeFileSync = (
         const { exists, localHash } = yield* readLocalHash(payload.path)
         if (!exists) return
 
+        if (isLocalOnly) {
+          yield* setLocalOnlyAvailableFileState(payload.id, payload.path, localHash)
+          return
+        }
+
         yield* applyFileState(payload.id, {
           path: payload.path,
           localHash,
@@ -885,6 +915,15 @@ export const makeFileSync = (
     const handleFileUpdated = (payload: FileUpdatedPayload): Effect.Effect<void> =>
       Effect.gen(function*() {
         const { exists, localHash } = yield* readLocalHash(payload.path)
+
+        if (isLocalOnly) {
+          if (exists) {
+            yield* setLocalOnlyAvailableFileState(payload.id, payload.path, localHash)
+          } else {
+            yield* stateManager.removeFile(payload.id)
+          }
+          return
+        }
 
         if (!exists) {
           if (!payload.remoteKey) return
@@ -998,6 +1037,21 @@ export const makeFileSync = (
           }
 
           const { exists, localHash } = yield* readLocalHash(file.path)
+
+          if (isLocalOnly) {
+            if (exists) {
+              nextState[file.id] = {
+                path: file.path,
+                localHash,
+                uploadStatus: "done",
+                downloadStatus: "done",
+                lastSyncError: ""
+              }
+            } else {
+              delete nextState[file.id]
+            }
+            continue
+          }
 
           if (!exists) {
             if (!file.remoteKey) continue
@@ -1139,6 +1193,34 @@ export const makeFileSync = (
     // Files in "error" state are also reset to give them another chance.
     const recoverStaleTransfers = (): Effect.Effect<void> =>
       Effect.gen(function*() {
+        if (isLocalOnly) {
+          yield* stateManager.atomicUpdate((currentState) => {
+            let hasChanges = false
+            const nextState = { ...currentState }
+
+            for (const [fileId, localFile] of Object.entries(nextState)) {
+              if (
+                localFile.uploadStatus === "done" &&
+                localFile.downloadStatus === "done" &&
+                localFile.lastSyncError === ""
+              ) {
+                continue
+              }
+
+              nextState[fileId] = {
+                ...localFile,
+                uploadStatus: "done",
+                downloadStatus: "done",
+                lastSyncError: ""
+              }
+              hasChanges = true
+            }
+
+            return hasChanges ? nextState : currentState
+          })
+          return
+        }
+
         const retriedFileIds: Array<string> = []
         const queuedUploadFileIds: Array<string> = []
         const queuedDownloadFileIds: Array<string> = []
@@ -1330,11 +1412,13 @@ export const makeFileSync = (
         // Run one-time stale transfer recovery before any transfers begin
         yield* maybeRecoverStaleTransfers()
 
-        const isOnline = yield* Ref.get(onlineRef)
-        if (isOnline) {
-          yield* executor.resume()
-        } else {
-          yield* executor.pause()
+        if (!isLocalOnly) {
+          const isOnline = yield* Ref.get(onlineRef)
+          if (isOnline) {
+            yield* executor.resume()
+          } else {
+            yield* executor.pause()
+          }
         }
         yield* maybeBootstrapFromTables()
         yield* startEventStream()
@@ -1551,8 +1635,10 @@ export const makeFileSync = (
         const scope = yield* Effect.scope
         yield* Ref.set(mainScopeRef, scope)
 
-        // Start the executor
-        yield* executor.start()
+        // Start transfer workers only when remote transfers are enabled.
+        if (!isLocalOnly) {
+          yield* executor.start()
+        }
 
         // Check initial lock status
         const initialStatus = yield* SubscriptionRef.get(clientSession.lockStatus)
@@ -1606,13 +1692,15 @@ export const makeFileSync = (
       path: string,
       hash: string
     ): Effect.Effect<void> =>
-      stateManager.setFileState(fileId, {
-        path,
-        localHash: hash,
-        downloadStatus: "done",
-        uploadStatus: "queued",
-        lastSyncError: ""
-      })
+      isLocalOnly
+        ? setLocalOnlyAvailableFileState(fileId, path, hash)
+        : stateManager.setFileState(fileId, {
+          path,
+          localHash: hash,
+          downloadStatus: "done",
+          uploadStatus: "queued",
+          lastSyncError: ""
+        })
 
     const saveFile = (file: File): Effect.Effect<FileOperationResult, HashError | StorageError> =>
       Effect.gen(function*() {
@@ -1674,7 +1762,7 @@ export const makeFileSync = (
             yield* localStorage.deleteFile(existingFile.path).pipe(Effect.catchAll(() => Effect.void))
           }
 
-          if (existingFile.remoteKey) {
+          if (!isLocalOnly && existingFile.remoteKey) {
             yield* remoteStorage.delete(existingFile.remoteKey).pipe(Effect.catchAll(() => Effect.void))
           }
 
@@ -1695,8 +1783,9 @@ export const makeFileSync = (
         yield* deleteFileRecord(fileId)
 
         yield* localStorage.deleteFile(existingFile.path).pipe(Effect.catchAll(() => Effect.void))
+        yield* stateManager.removeFile(fileId)
 
-        if (existingFile.remoteKey) {
+        if (!isLocalOnly && existingFile.remoteKey) {
           yield* remoteStorage.delete(existingFile.remoteKey).pipe(Effect.catchAll(() => Effect.void))
         }
       })
@@ -1710,6 +1799,15 @@ export const makeFileSync = (
 
         const localState = yield* getLocalFilesState()
         const local = localState[fileId]
+
+        if (isLocalOnly) {
+          const exists = yield* localStorage.fileExists(file.path)
+          if (!exists) return null
+          if (isNode()) {
+            return resolveLocalFileUrl(deps.localPathRoot, file.path)
+          }
+          return yield* localStorage.getFileUrl(file.path)
+        }
 
         if (local?.localHash) {
           const exists = yield* localStorage.fileExists(file.path)
@@ -1741,6 +1839,11 @@ export const makeFileSync = (
 
     const setOnline = (online: boolean): Effect.Effect<void> =>
       Effect.gen(function*() {
+        if (isLocalOnly) {
+          yield* Ref.set(onlineRef, true)
+          return
+        }
+
         const wasOnline = yield* Ref.get(onlineRef)
         if (online === wasOnline) return
 
@@ -1764,10 +1867,13 @@ export const makeFileSync = (
       }
     }
 
-    const prioritizeDownload = (fileId: string): Effect.Effect<void> => executor.prioritizeDownload(fileId)
+    const prioritizeDownload = (fileId: string): Effect.Effect<void> =>
+      isLocalOnly ? Effect.void : executor.prioritizeDownload(fileId)
 
     const retryErrors = (): Effect.Effect<ReadonlyArray<string>> =>
       Effect.gen(function*() {
+        if (isLocalOnly) return []
+
         const retriedFileIds: Array<string> = []
         const currentState = yield* stateManager.getState()
 

--- a/packages/core/src/services/file-sync/FileSync.ts
+++ b/packages/core/src/services/file-sync/FileSync.ts
@@ -33,6 +33,7 @@ import { getClientSession, type LiveStoreDeps } from "../../livestore/types.js"
 import type {
   FileCreatedPayload,
   FileDeletedPayload,
+  FileMetadata,
   FileOperationResult,
   FileRecord,
   FileSyncEvent,
@@ -44,7 +45,7 @@ import type {
   PreprocessorMap,
   TransferStatus
 } from "../../types/index.js"
-import { applyPreprocessor, makeStoredPath } from "../../utils/index.js"
+import { applyPreprocessorWithMetadata, makeStoredPath } from "../../utils/index.js"
 import { stripFilesRoot } from "../../utils/path.js"
 import { Hash } from "../hash/index.js"
 import { LocalFileStateManager } from "../local-file-state/index.js"
@@ -286,6 +287,29 @@ export const makeFileSync = (
     // Local wrapper for hashFile that uses the captured hash service
     const doHashFile = (file: File) => hashService.hashFile(file)
 
+    const serializeFileMetadata = (
+      file: File,
+      metadata: FileMetadata | undefined
+    ): Effect.Effect<string | null, StorageError> =>
+      Effect.try({
+        try: () => {
+          if (!metadata) return null
+          const normalized: FileMetadata = {
+            ...metadata,
+            ...(metadata.mimeType === undefined && file.type ? { mimeType: file.type } : {}),
+            ...(metadata.sizeBytes === undefined ? { sizeBytes: file.size } : {})
+          }
+          return JSON.stringify(normalized)
+        },
+        catch: (error) =>
+          new StorageError({
+            message: `Failed to serialize metadata for ${file.name}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            cause: error
+          })
+      })
+
     // Get client session for leader election
     const clientSession = getClientSession(store)
 
@@ -356,12 +380,13 @@ export const makeFileSync = (
             path: file.path,
             remoteKey,
             contentHash: file.contentHash,
+            metadataJson: file.metadataJson,
             updatedAt: new Date()
           })
         )
       })
 
-    const createFileRecord = (params: { id: string; path: string; contentHash: string }) =>
+    const createFileRecord = (params: { id: string; path: string; contentHash: string; metadataJson: string | null }) =>
       Effect.sync(() => {
         console.log("createFileRecord file ID:", params.id)
         store.commit(
@@ -369,6 +394,7 @@ export const makeFileSync = (
             id: params.id,
             path: params.path,
             contentHash: params.contentHash,
+            metadataJson: params.metadataJson,
             createdAt: new Date(),
             updatedAt: new Date()
           })
@@ -379,6 +405,7 @@ export const makeFileSync = (
       id: string
       path: string
       contentHash: string
+      metadataJson: string | null
       remoteKey?: string
     }) =>
       Effect.gen(function*() {
@@ -390,6 +417,7 @@ export const makeFileSync = (
             path: params.path,
             remoteKey: params.remoteKey ?? file.remoteKey,
             contentHash: params.contentHash,
+            metadataJson: params.metadataJson,
             updatedAt: new Date()
           })
         )
@@ -1591,21 +1619,23 @@ export const makeFileSync = (
         // Apply preprocessor if configured for this file type
         // Use tryPromise so rejected/throwing preprocessors produce a caught error
         // instead of a defect that crashes the fiber
-        const processedFile = yield* Effect.tryPromise({
-          try: () => applyPreprocessor(config.preprocessors, file),
+        const processed = yield* Effect.tryPromise({
+          try: () => applyPreprocessorWithMetadata(config.preprocessors, file),
           catch: (err) =>
             new StorageError({
               message: `Preprocessor failed for ${file.name}: ${err instanceof Error ? err.message : String(err)}`,
               cause: err
             })
         })
+        const processedFile = processed.file
+        const metadataJson = yield* serializeFileMetadata(processedFile, processed.metadata)
 
         const id = crypto.randomUUID()
         const contentHash = yield* doHashFile(processedFile)
         const path = makeStoredPath(storeId, contentHash)
 
         yield* localStorage.writeFile(path, processedFile)
-        yield* createFileRecord({ id, path, contentHash })
+        yield* createFileRecord({ id, path, contentHash, metadataJson })
         yield* markLocalFileChanged(id, path, contentHash)
 
         return { fileId: id, path, contentHash }
@@ -1622,21 +1652,23 @@ export const makeFileSync = (
         }
 
         // Apply preprocessor if configured for this file type
-        const processedFile = yield* Effect.tryPromise({
-          try: () => applyPreprocessor(config.preprocessors, file),
+        const processed = yield* Effect.tryPromise({
+          try: () => applyPreprocessorWithMetadata(config.preprocessors, file),
           catch: (err) =>
             new StorageError({
               message: `Preprocessor failed for ${file.name}: ${err instanceof Error ? err.message : String(err)}`,
               cause: err
             })
         })
+        const processedFile = processed.file
+        const metadataJson = yield* serializeFileMetadata(processedFile, processed.metadata)
 
         const contentHash = yield* doHashFile(processedFile)
         const path = makeStoredPath(storeId, contentHash)
 
         if (contentHash !== existingFile.contentHash) {
           yield* localStorage.writeFile(path, processedFile)
-          yield* updateFileRecord({ id: fileId, path, contentHash, remoteKey: "" })
+          yield* updateFileRecord({ id: fileId, path, contentHash, metadataJson, remoteKey: "" })
 
           if (path !== existingFile.path) {
             yield* localStorage.deleteFile(existingFile.path).pipe(Effect.catchAll(() => Effect.void))

--- a/packages/core/src/services/remote-file-storage/RemoteStorage.ts
+++ b/packages/core/src/services/remote-file-storage/RemoteStorage.ts
@@ -47,6 +47,14 @@ export interface RemoteStorageConfig {
 }
 
 /**
+ * Remote configuration used when FileSync is explicitly running without a
+ * remote backend.
+ */
+export interface LocalOnlyRemoteStorageConfig {
+  readonly mode: "local-only"
+}
+
+/**
  * Result of an upload
  */
 export interface RemoteUploadResult {
@@ -136,7 +144,7 @@ export interface RemoteStorageService extends RemoteStorageAdapter {
   /**
    * Get the current configuration
    */
-  readonly getConfig: () => RemoteStorageConfig
+  readonly getConfig: () => RemoteStorageConfig | LocalOnlyRemoteStorageConfig
 }
 
 /**
@@ -504,6 +512,55 @@ export const makeS3SignerRemoteStorage = (config: RemoteStorageConfig): RemoteSt
     getDownloadUrl,
     checkHealth,
     getConfig
+  }
+}
+
+/**
+ * Create a RemoteStorage implementation for explicit local-only FileSync mode.
+ *
+ * FileSync orchestration should not call transfer methods in this mode. The
+ * adapter exists only to keep Effect layer wiring simple and fails loudly if a
+ * remote operation accidentally leaks through.
+ */
+export const makeLocalOnlyRemoteStorage = (): RemoteStorageService => {
+  const disabledUpload = () =>
+    Effect.fail(
+      new UploadError({
+        message: "Remote upload is disabled because FileSync is running in local-only mode"
+      })
+    )
+
+  const disabledDownload = (key: string) =>
+    Effect.fail(
+      new DownloadError({
+        message: "Remote download is disabled because FileSync is running in local-only mode",
+        url: key
+      })
+    )
+
+  const disabledDownloadUrl = (key: string) =>
+    Effect.fail(
+      new DownloadError({
+        message: "Remote download URL signing is disabled because FileSync is running in local-only mode",
+        url: key
+      })
+    )
+
+  const disabledDelete = (key: string) =>
+    Effect.fail(
+      new DeleteError({
+        message: "Remote delete is disabled because FileSync is running in local-only mode",
+        path: key
+      })
+    )
+
+  return {
+    upload: disabledUpload,
+    download: disabledDownload,
+    delete: disabledDelete,
+    getDownloadUrl: disabledDownloadUrl,
+    checkHealth: () => Effect.succeed(true),
+    getConfig: () => ({ mode: "local-only" })
   }
 }
 

--- a/packages/core/src/services/remote-file-storage/index.ts
+++ b/packages/core/src/services/remote-file-storage/index.ts
@@ -6,6 +6,8 @@
 
 export {
   type DownloadOptions,
+  type LocalOnlyRemoteStorageConfig,
+  makeLocalOnlyRemoteStorage,
   makeRemoteStorageLive,
   makeS3SignerRemoteStorage,
   RemoteStorage,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -14,6 +14,7 @@ import type { Schema } from "@livestore/livestore"
 import type {
   FileCreatedPayloadSchema,
   FileDeletedPayloadSchema,
+  FileMetadataSchema,
   FileSyncCursorSchema,
   FileSyncTables,
   FileUpdatedPayloadSchema,
@@ -80,6 +81,12 @@ export type LocalFilesStateMutable = Schema.Schema.Type<ReturnType<typeof Schema
  * Derived from the files table schema
  */
 export type FileRecord = FileSyncTables["files"]["rowSchema"]["Type"]
+
+/**
+ * Optional metadata describing a synced file.
+ * Metadata is associated with the file record's current contentHash.
+ */
+export type FileMetadata = typeof FileMetadataSchema.Type
 
 /**
  * File created event payload
@@ -256,18 +263,35 @@ export type ActiveTransfers = Readonly<Record<string, ActiveTransferProgress>>
 // ============================================
 
 /**
+ * Result returned by a file preprocessor.
+ */
+export type FilePreprocessorResult = File | {
+  readonly file: File
+  readonly metadata?: FileMetadata
+}
+
+/**
+ * Normalized result returned after applying a preprocessor.
+ */
+export interface AppliedPreprocessorResult {
+  readonly file: File
+  readonly metadata?: FileMetadata
+}
+
+/**
  * A file preprocessor transforms a file before it's saved.
- * Returns the transformed file (or the original if no transformation needed).
+ * Returns the transformed file (or the original if no transformation needed),
+ * optionally with metadata for the final file.
  *
  * @example
  * ```typescript
  * const resizeImage: FilePreprocessor = async (file) => {
  *   // Transform the file...
- *   return transformedFile
+ *   return { file: transformedFile, metadata: { image: { width, height } } }
  * }
  * ```
  */
-export type FilePreprocessor = (file: File) => Promise<File>
+export type FilePreprocessor = (file: File) => Promise<FilePreprocessorResult>
 
 /**
  * Map of MIME type patterns to preprocessor functions.
@@ -287,6 +311,28 @@ export type FilePreprocessor = (file: File) => Promise<File>
  * ```
  */
 export type PreprocessorMap = Record<string, FilePreprocessor>
+
+/**
+ * Parse the JSON metadata stored on a file row.
+ * Returns null for missing or malformed metadata.
+ */
+export function parseFileMetadata(metadataJson?: string | null): FileMetadata | null {
+  if (!metadataJson) return null
+  try {
+    const parsed = JSON.parse(metadataJson) as unknown
+    if (!parsed || typeof parsed !== "object") return null
+    return parsed as FileMetadata
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Get parsed metadata from a file record.
+ */
+export function getFileMetadata(file: FileRecord): FileMetadata | null {
+  return parseFileMetadata(file.metadataJson)
+}
 
 // ============================================
 // Display State Utilities

--- a/packages/core/src/utils/mime.test.ts
+++ b/packages/core/src/utils/mime.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 import type { PreprocessorMap } from "../types/index.js"
-import { applyPreprocessor, findPreprocessor, matchMimeType } from "./mime.js"
+import {
+  applyPreprocessor,
+  applyPreprocessorWithMetadata,
+  findPreprocessor,
+  matchMimeType,
+  normalizePreprocessorResult
+} from "./mime.js"
 
 describe("matchMimeType", () => {
   describe("exact matches", () => {
@@ -179,6 +185,20 @@ describe("applyPreprocessor", () => {
     expect(result.type).toBe("image/jpeg")
   })
 
+  it("should return only the file from metadata-capable preprocessor results", async () => {
+    const preprocessors: PreprocessorMap = {
+      "image/*": async (file) => ({
+        file: new File([await file.arrayBuffer()], "processed.jpg", { type: "image/jpeg" }),
+        metadata: { image: { width: 100, height: 50 } }
+      })
+    }
+    const file = new File(["content"], "test.png", { type: "image/png" })
+    const result = await applyPreprocessor(preprocessors, file)
+
+    expect(result.name).toBe("processed.jpg")
+    expect(result.type).toBe("image/jpeg")
+  })
+
   it("should handle async preprocessors", async () => {
     let preprocessorCalled = false
     const preprocessors: PreprocessorMap = {
@@ -208,6 +228,54 @@ describe("applyPreprocessor", () => {
     await applyPreprocessor(preprocessors, file)
 
     expect(receivedFile).toBe(file)
+  })
+})
+
+describe("applyPreprocessorWithMetadata", () => {
+  it("returns original file without metadata when no preprocessor matches", async () => {
+    const file = new File(["content"], "test.txt", { type: "text/plain" })
+    const result = await applyPreprocessorWithMetadata({ "image/*": async (file) => file }, file)
+
+    expect(result).toEqual({ file })
+  })
+
+  it("preserves metadata from metadata-capable preprocessor results", async () => {
+    const preprocessors: PreprocessorMap = {
+      "image/*": async (file) => ({
+        file,
+        metadata: {
+          mimeType: "image/png",
+          sizeBytes: file.size,
+          image: { width: 10, height: 20 },
+          custom: { source: "test" }
+        }
+      })
+    }
+    const file = new File(["content"], "test.png", { type: "image/png" })
+    const result = await applyPreprocessorWithMetadata(preprocessors, file)
+
+    expect(result.file).toBe(file)
+    expect(result.metadata).toEqual({
+      mimeType: "image/png",
+      sizeBytes: file.size,
+      image: { width: 10, height: 20 },
+      custom: { source: "test" }
+    })
+  })
+})
+
+describe("normalizePreprocessorResult", () => {
+  it("normalizes File results", () => {
+    const file = new File(["content"], "test.txt")
+    expect(normalizePreprocessorResult(file)).toEqual({ file })
+  })
+
+  it("normalizes object results", () => {
+    const file = new File(["content"], "test.txt")
+    expect(normalizePreprocessorResult({ file, metadata: { sizeBytes: 7 } })).toEqual({
+      file,
+      metadata: { sizeBytes: 7 }
+    })
   })
 })
 

--- a/packages/core/src/utils/mime.ts
+++ b/packages/core/src/utils/mime.ts
@@ -4,7 +4,12 @@
  * @module
  */
 
-import type { FilePreprocessor, PreprocessorMap } from "../types/index.js"
+import type {
+  AppliedPreprocessorResult,
+  FilePreprocessor,
+  FilePreprocessorResult,
+  PreprocessorMap
+} from "../types/index.js"
 
 /**
  * Match a MIME type against a pattern with wildcard support.
@@ -144,14 +149,41 @@ export async function applyPreprocessor(
   preprocessors: PreprocessorMap | undefined,
   file: File
 ): Promise<File> {
+  const result = await applyPreprocessorWithMetadata(preprocessors, file)
+  return result.file
+}
+
+/**
+ * Normalize a file preprocessor result into an object shape.
+ */
+export function normalizePreprocessorResult(result: FilePreprocessorResult): AppliedPreprocessorResult {
+  if (result && typeof result === "object" && "file" in result) {
+    return {
+      file: result.file,
+      ...(result.metadata !== undefined ? { metadata: result.metadata } : {})
+    }
+  }
+
+  return { file: result }
+}
+
+/**
+ * Apply the appropriate preprocessor and preserve any metadata it returns.
+ *
+ * If no matching preprocessor is found, the original file is returned without metadata.
+ */
+export async function applyPreprocessorWithMetadata(
+  preprocessors: PreprocessorMap | undefined,
+  file: File
+): Promise<AppliedPreprocessorResult> {
   if (!preprocessors || Object.keys(preprocessors).length === 0) {
-    return file
+    return { file }
   }
 
   const preprocessor = findPreprocessor(preprocessors, file.type)
   if (!preprocessor) {
-    return file
+    return { file }
   }
 
-  return preprocessor(file)
+  return normalizePreprocessorResult(await preprocessor(file))
 }

--- a/packages/core/test/utils.test.ts
+++ b/packages/core/test/utils.test.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import type { Hash } from "../src/services/hash/HashService.js"
 import { HashServiceLive } from "../src/services/hash/index.js"
+import { getFileMetadata, parseFileMetadata } from "../src/types/index.js"
 import {
   extractHashFromPath,
   FILES_DIRECTORY,
@@ -82,6 +83,45 @@ describe("path utilities", () => {
     it("should build a store-scoped root path", () => {
       expect(makeStoreRoot("store/one")).toBe(`${FILES_DIRECTORY}/store_one`)
     })
+  })
+})
+
+describe("file metadata utilities", () => {
+  it("parses valid metadata JSON", () => {
+    const metadata = parseFileMetadata(JSON.stringify({
+      mimeType: "image/png",
+      sizeBytes: 123,
+      image: { width: 10, height: 20 },
+      custom: { source: "test" }
+    }))
+
+    expect(metadata).toEqual({
+      mimeType: "image/png",
+      sizeBytes: 123,
+      image: { width: 10, height: 20 },
+      custom: { source: "test" }
+    })
+  })
+
+  it("returns null for missing or malformed metadata JSON", () => {
+    expect(parseFileMetadata(null)).toBeNull()
+    expect(parseFileMetadata("")).toBeNull()
+    expect(parseFileMetadata("not-json")).toBeNull()
+  })
+
+  it("reads metadata from file records", () => {
+    const metadata = getFileMetadata({
+      id: "file-1",
+      path: "path",
+      remoteKey: "",
+      contentHash: "hash",
+      metadataJson: JSON.stringify({ sizeBytes: 7 }),
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      deletedAt: null
+    })
+
+    expect(metadata).toEqual({ sizeBytes: 7 })
   })
 })
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/expo",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "Expo filesystem and image processing adapters for livestore-filesync",

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -113,6 +113,8 @@ initFileSync(store, {
 })
 ```
 
+Image preprocessors return metadata for the final stored file. FileSync persists this on the synced `files` row so apps can read `getFileMetadata(fileRecord)?.image` and reserve the correct image aspect ratio before a file or thumbnail URL resolves.
+
 ### Preprocessor API
 
 #### `createImagePreprocessor(options?)`

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/image",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "Image preprocessing and thumbnail generation for livestore-filesync using wasm-vips",

--- a/packages/image/src/preprocessor/canvas-preprocessor.ts
+++ b/packages/image/src/preprocessor/canvas-preprocessor.ts
@@ -83,6 +83,36 @@ function getMimeType(format: ImageFormat): string {
   }
 }
 
+type ImageDimensions = {
+  readonly width: number
+  readonly height: number
+}
+
+const getFileMetadata = (
+  file: File,
+  dimensions?: ImageDimensions
+) => ({
+  ...(file.type ? { mimeType: file.type } : {}),
+  sizeBytes: file.size,
+  ...(dimensions ? { image: dimensions } : {})
+})
+
+const getImageDimensions = async (arrayBuffer: ArrayBuffer): Promise<ImageDimensions | undefined> => {
+  if (typeof createImageBitmap !== "function") return undefined
+
+  const bitmap = await createImageBitmap(new Blob([arrayBuffer])).catch(() => undefined)
+  if (!bitmap) return undefined
+
+  try {
+    return {
+      width: bitmap.width,
+      height: bitmap.height
+    }
+  } finally {
+    bitmap.close()
+  }
+}
+
 /**
  * Create a canvas-based image preprocessor.
  *
@@ -129,10 +159,15 @@ export function createCanvasImagePreprocessor(options: CanvasImagePreprocessorOp
   const targetMimeType = getMimeType(format)
   const processor = createCanvasProcessor()
 
-  return async (file: File): Promise<File> => {
+  return async (file: File) => {
+    const arrayBuffer = await file.arrayBuffer()
+
     // Skip if below size threshold
     if (minSizeThreshold > 0 && file.size < minSizeThreshold) {
-      return file
+      return {
+        file,
+        metadata: getFileMetadata(file, await getImageDimensions(arrayBuffer))
+      }
     }
 
     // Check if already in target format
@@ -140,11 +175,11 @@ export function createCanvasImagePreprocessor(options: CanvasImagePreprocessorOp
 
     // Early exit: if already target format and no resizing configured, skip entirely
     if (isTargetFormat && maxDimension === 0) {
-      return file
+      return {
+        file,
+        metadata: getFileMetadata(file, await getImageDimensions(arrayBuffer))
+      }
     }
-
-    // Read file into buffer for dimension check
-    const arrayBuffer = await file.arrayBuffer()
 
     // Initialize processor if needed
     if (!processor.isInitialized()) {
@@ -160,16 +195,17 @@ export function createCanvasImagePreprocessor(options: CanvasImagePreprocessorOp
     })
 
     // Check if the image was actually modified
-    const blob = new Blob([arrayBuffer])
-    const bitmap = await createImageBitmap(blob)
-    const originalWidth = bitmap.width
-    const originalHeight = bitmap.height
-    bitmap.close()
+    const dimensions = await getImageDimensions(arrayBuffer)
+    const originalWidth = dimensions?.width ?? result.width
+    const originalHeight = dimensions?.height ?? result.height
 
     // If already in target format and within bounds, return original
     const withinBounds = maxDimension === 0 || (originalWidth <= maxDimension && originalHeight <= maxDimension)
     if (isTargetFormat && withinBounds) {
-      return file
+      return {
+        file,
+        metadata: getFileMetadata(file, { width: originalWidth, height: originalHeight })
+      }
     }
 
     // Generate new filename
@@ -177,7 +213,11 @@ export function createCanvasImagePreprocessor(options: CanvasImagePreprocessorOp
     const newFilename = `${baseName}.${getExtension(format)}`
 
     // Use MemoryFile for React Native compatibility
-    return new MemoryFile(new Uint8Array(result.data), newFilename, result.mimeType) as unknown as File
+    const processedFile = new MemoryFile(new Uint8Array(result.data), newFilename, result.mimeType) as unknown as File
+    return {
+      file: processedFile,
+      metadata: getFileMetadata(processedFile, { width: result.width, height: result.height })
+    }
   }
 }
 
@@ -191,7 +231,7 @@ export function createCanvasImagePreprocessor(options: CanvasImagePreprocessorOp
 export function createCanvasResizeOnlyPreprocessor(maxDimension: number): FilePreprocessor {
   const processor = createCanvasProcessor()
 
-  return async (file: File): Promise<File> => {
+  return async (file: File) => {
     // Determine output format from input MIME type
     let format: ImageFormat = "jpeg"
     if (file.type === "image/png") {
@@ -204,15 +244,16 @@ export function createCanvasResizeOnlyPreprocessor(maxDimension: number): FilePr
     const arrayBuffer = await file.arrayBuffer()
 
     // Check dimensions first
-    const blob = new Blob([arrayBuffer])
-    const bitmap = await createImageBitmap(blob)
-    const width = bitmap.width
-    const height = bitmap.height
-    bitmap.close()
+    const dimensions = await getImageDimensions(arrayBuffer)
+    const width = dimensions?.width ?? 0
+    const height = dimensions?.height ?? 0
 
     // Skip if already within bounds
-    if (width <= maxDimension && height <= maxDimension) {
-      return file
+    if (dimensions && width <= maxDimension && height <= maxDimension) {
+      return {
+        file,
+        metadata: getFileMetadata(file, dimensions)
+      }
     }
 
     // Initialize processor if needed
@@ -228,6 +269,10 @@ export function createCanvasResizeOnlyPreprocessor(maxDimension: number): FilePr
       keepIccProfile: true
     })
 
-    return new MemoryFile(new Uint8Array(result.data), file.name, file.type) as unknown as File
+    const processedFile = new MemoryFile(new Uint8Array(result.data), file.name, result.mimeType) as unknown as File
+    return {
+      file: processedFile,
+      metadata: getFileMetadata(processedFile, { width: result.width, height: result.height })
+    }
   }
 }

--- a/packages/image/src/preprocessor/preprocessor.test.ts
+++ b/packages/image/src/preprocessor/preprocessor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { createCanvasImagePreprocessor } from "./canvas-preprocessor.js"
 import {
   createImagePreprocessor,
   createResizeOnlyPreprocessor,
@@ -18,6 +19,79 @@ import {
  * packages/core/src/utils/mime.test.ts > "applyPreprocessor - skip behavior patterns"
  * packages/core/src/services/file-sync/FileSync.storage.test.ts > "FileSync - Preprocessor integration"
  */
+
+const withMockImageBitmap = async <T>(
+  dimensions: { width: number; height: number },
+  fn: () => Promise<T>
+): Promise<T> => {
+  const previous = globalThis.createImageBitmap
+  globalThis.createImageBitmap = (async () => ({
+    width: dimensions.width,
+    height: dimensions.height,
+    close: () => {}
+  })) as typeof createImageBitmap
+  try {
+    return await fn()
+  } finally {
+    globalThis.createImageBitmap = previous
+  }
+}
+
+const withRejectingImageBitmap = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const previous = globalThis.createImageBitmap
+  globalThis.createImageBitmap = (async () => {
+    throw new Error("decode failed")
+  }) as typeof createImageBitmap
+  try {
+    return await fn()
+  } finally {
+    globalThis.createImageBitmap = previous
+  }
+}
+
+const withMockCanvasApi = async <T>(
+  dimensions: { width: number; height: number },
+  fn: () => Promise<T>
+): Promise<T> => {
+  const previousImageBitmap = globalThis.createImageBitmap
+  const previousOffscreenCanvas = globalThis.OffscreenCanvas
+
+  class MockOffscreenCanvas {
+    readonly width: number
+    readonly height: number
+
+    constructor(width: number, height: number) {
+      this.width = width
+      this.height = height
+    }
+
+    getContext() {
+      return {
+        imageSmoothingEnabled: false,
+        imageSmoothingQuality: "low",
+        drawImage: () => {}
+      }
+    }
+
+    async convertToBlob(options?: ImageEncodeOptions) {
+      return new Blob(["processed"], { type: options?.type ?? "image/png" })
+    }
+  }
+
+  globalThis.createImageBitmap = (async () => ({
+    width: dimensions.width,
+    height: dimensions.height,
+    close: () => {}
+  })) as typeof createImageBitmap
+  globalThis.OffscreenCanvas = MockOffscreenCanvas as unknown as typeof OffscreenCanvas
+
+  try {
+    return await fn()
+  } finally {
+    globalThis.createImageBitmap = previousImageBitmap
+    globalThis.OffscreenCanvas = previousOffscreenCanvas
+  }
+}
 
 describe("defaultImagePreprocessorOptions", () => {
   it("should have correct default values", () => {
@@ -70,7 +144,31 @@ describe("createImagePreprocessor", () => {
 
       // Should return original file unchanged (no WASM needed)
       const result = await preprocessor(smallFile)
-      expect(result).toBe(smallFile)
+      expect(result).toEqual({
+        file: smallFile,
+        metadata: {
+          mimeType: "image/png",
+          sizeBytes: smallFile.size
+        }
+      })
+    })
+
+    it("returns dimensions for skipped files when dimensions can be extracted", async () => {
+      const preprocessor = createImagePreprocessor({
+        minSizeThreshold: 1000
+      })
+      const smallFile = new File(["tiny"], "small.png", { type: "image/png" })
+
+      const result = await withMockImageBitmap({ width: 40, height: 20 }, () => preprocessor(smallFile))
+
+      expect(result).toEqual({
+        file: smallFile,
+        metadata: {
+          mimeType: "image/png",
+          sizeBytes: smallFile.size,
+          image: { width: 40, height: 20 }
+        }
+      })
     })
 
     it("does not skip files at or above size threshold", async () => {
@@ -101,7 +199,13 @@ describe("createImagePreprocessor", () => {
 
       // Should return original file (early exit before WASM load)
       const result = await preprocessor(jpegFile)
-      expect(result).toBe(jpegFile)
+      expect(result).toEqual({
+        file: jpegFile,
+        metadata: {
+          mimeType: "image/jpeg",
+          sizeBytes: jpegFile.size
+        }
+      })
     })
 
     it("skips already-matching webp format when maxDimension is 0", async () => {
@@ -112,7 +216,13 @@ describe("createImagePreprocessor", () => {
 
       const webpFile = new File(["webp data"], "image.webp", { type: "image/webp" })
       const result = await preprocessor(webpFile)
-      expect(result).toBe(webpFile)
+      expect(result).toEqual({
+        file: webpFile,
+        metadata: {
+          mimeType: "image/webp",
+          sizeBytes: webpFile.size
+        }
+      })
     })
 
     it("skips already-matching png format when maxDimension is 0", async () => {
@@ -123,7 +233,70 @@ describe("createImagePreprocessor", () => {
 
       const pngFile = new File(["png data"], "image.png", { type: "image/png" })
       const result = await preprocessor(pngFile)
-      expect(result).toBe(pngFile)
+      expect(result).toEqual({
+        file: pngFile,
+        metadata: {
+          mimeType: "image/png",
+          sizeBytes: pngFile.size
+        }
+      })
+    })
+
+    it("returns final dimensions for unchanged target-format files", async () => {
+      const preprocessor = createImagePreprocessor({
+        format: "jpeg",
+        maxDimension: 0
+      })
+      const jpegFile = new File(["jpeg data"], "photo.jpg", { type: "image/jpeg" })
+
+      const result = await withMockImageBitmap({ width: 640, height: 480 }, () => preprocessor(jpegFile))
+
+      expect(result).toEqual({
+        file: jpegFile,
+        metadata: {
+          mimeType: "image/jpeg",
+          sizeBytes: jpegFile.size,
+          image: { width: 640, height: 480 }
+        }
+      })
+    })
+
+    it("preserves skip behavior when dimension probing fails", async () => {
+      const preprocessor = createImagePreprocessor({
+        format: "png",
+        maxDimension: 0
+      })
+      const pngFile = new File(["png data"], "image.png", { type: "image/png" })
+
+      const result = await withRejectingImageBitmap(() => preprocessor(pngFile))
+
+      expect(result).toEqual({
+        file: pngFile,
+        metadata: {
+          mimeType: "image/png",
+          sizeBytes: pngFile.size
+        }
+      })
+    })
+
+    it("returns final dimensions for transformed canvas-backed images", async () => {
+      const preprocessor = createImagePreprocessor({
+        processor: "canvas",
+        format: "jpeg",
+        maxDimension: 50
+      })
+      const pngFile = new File(["png data"], "image.png", { type: "image/png" })
+
+      const result = await withMockCanvasApi({ width: 100, height: 50 }, () => preprocessor(pngFile))
+
+      expect(result).toMatchObject({
+        metadata: {
+          mimeType: "image/jpeg",
+          sizeBytes: "processed".length,
+          image: { width: 50, height: 25 }
+        }
+      })
+      expect((result as { file: File }).file.type).toBe("image/jpeg")
     })
 
     it("does not skip when format does not match (even with maxDimension=0)", async () => {
@@ -137,6 +310,27 @@ describe("createImagePreprocessor", () => {
 
       // Should try to process (and fail because WASM isn't available)
       await expect(preprocessor(pngFile)).rejects.toThrow()
+    })
+  })
+})
+
+describe("createCanvasImagePreprocessor", () => {
+  it("returns metadata for unchanged images", async () => {
+    const preprocessor = createCanvasImagePreprocessor({
+      format: "png",
+      maxDimension: 0
+    })
+    const pngFile = new File(["png data"], "image.png", { type: "image/png" })
+
+    const result = await withMockImageBitmap({ width: 100, height: 75 }, () => preprocessor(pngFile))
+
+    expect(result).toEqual({
+      file: pngFile,
+      metadata: {
+        mimeType: "image/png",
+        sizeBytes: pngFile.size,
+        image: { width: 100, height: 75 }
+      }
     })
   })
 })

--- a/packages/image/src/preprocessor/preprocessor.ts
+++ b/packages/image/src/preprocessor/preprocessor.ts
@@ -112,6 +112,36 @@ function getMimeType(format: ImageFormat): string {
   }
 }
 
+type ImageDimensions = {
+  readonly width: number
+  readonly height: number
+}
+
+const getFileMetadata = (
+  file: File,
+  dimensions?: ImageDimensions
+) => ({
+  ...(file.type ? { mimeType: file.type } : {}),
+  sizeBytes: file.size,
+  ...(dimensions ? { image: dimensions } : {})
+})
+
+const getImageDimensions = async (arrayBuffer: ArrayBuffer): Promise<ImageDimensions | undefined> => {
+  if (typeof createImageBitmap !== "function") return undefined
+
+  const bitmap = await createImageBitmap(new Blob([arrayBuffer])).catch(() => undefined)
+  if (!bitmap) return undefined
+
+  try {
+    return {
+      width: bitmap.width,
+      height: bitmap.height
+    }
+  } finally {
+    bitmap.close()
+  }
+}
+
 /**
  * Create an image preprocessor with the given options.
  *
@@ -186,10 +216,15 @@ export function createImagePreprocessor(options: ImagePreprocessorOptions = {}):
     return processor
   }
 
-  return async (file: File): Promise<File> => {
+  return async (file: File) => {
+    const arrayBuffer = await file.arrayBuffer()
+
     // Skip if below size threshold
     if (minSizeThreshold > 0 && file.size < minSizeThreshold) {
-      return file
+      return {
+        file,
+        metadata: getFileMetadata(file, await getImageDimensions(arrayBuffer))
+      }
     }
 
     // Check if already in target format
@@ -197,11 +232,11 @@ export function createImagePreprocessor(options: ImagePreprocessorOptions = {}):
 
     // Early exit: if already target format and no resizing configured, skip entirely
     if (isTargetFormat && maxDimension === 0) {
-      return file
+      return {
+        file,
+        metadata: getFileMetadata(file, await getImageDimensions(arrayBuffer))
+      }
     }
-
-    // Read file into buffer for dimension check
-    const arrayBuffer = await file.arrayBuffer()
 
     // Get or create the processor (lazy init, dynamic import for vips)
     const proc = await getProcessor()
@@ -221,16 +256,17 @@ export function createImagePreprocessor(options: ImagePreprocessorOptions = {}):
 
     // Check if the image was actually modified
     // If dimensions match and format matches, original might have been within bounds
-    const blob = new Blob([arrayBuffer])
-    const bitmap = await createImageBitmap(blob)
-    const originalWidth = bitmap.width
-    const originalHeight = bitmap.height
-    bitmap.close()
+    const dimensions = await getImageDimensions(arrayBuffer)
+    const originalWidth = dimensions?.width ?? result.width
+    const originalHeight = dimensions?.height ?? result.height
 
     // If already in target format and within bounds, return original
     const withinBounds = maxDimension === 0 || (originalWidth <= maxDimension && originalHeight <= maxDimension)
     if (isTargetFormat && withinBounds) {
-      return file
+      return {
+        file,
+        metadata: getFileMetadata(file, { width: originalWidth, height: originalHeight })
+      }
     }
 
     // Generate new filename
@@ -239,7 +275,11 @@ export function createImagePreprocessor(options: ImagePreprocessorOptions = {}):
 
     // Use MemoryFile for React Native compatibility
     // React Native's File/Blob constructors don't properly support ArrayBuffer
-    return new MemoryFile(new Uint8Array(result.data), newFilename, result.mimeType) as unknown as File
+    const processedFile = new MemoryFile(new Uint8Array(result.data), newFilename, result.mimeType) as unknown as File
+    return {
+      file: processedFile,
+      metadata: getFileMetadata(processedFile, { width: result.width, height: result.height })
+    }
   }
 }
 
@@ -278,7 +318,7 @@ export function createResizeOnlyPreprocessor(
     return processor
   }
 
-  return async (file: File): Promise<File> => {
+  return async (file: File) => {
     // Determine output format from input MIME type
     let format: "jpeg" | "webp" | "png" = "jpeg"
     if (file.type === "image/png") {
@@ -291,15 +331,16 @@ export function createResizeOnlyPreprocessor(
     const arrayBuffer = await file.arrayBuffer()
 
     // Check dimensions first
-    const blob = new Blob([arrayBuffer])
-    const bitmap = await createImageBitmap(blob)
-    const width = bitmap.width
-    const height = bitmap.height
-    bitmap.close()
+    const dimensions = await getImageDimensions(arrayBuffer)
+    const width = dimensions?.width ?? 0
+    const height = dimensions?.height ?? 0
 
     // Skip if already within bounds
-    if (width <= maxDimension && height <= maxDimension) {
-      return file
+    if (dimensions && width <= maxDimension && height <= maxDimension) {
+      return {
+        file,
+        metadata: getFileMetadata(file, dimensions)
+      }
     }
 
     // Get or create the processor (lazy init, dynamic import for vips)
@@ -320,6 +361,10 @@ export function createResizeOnlyPreprocessor(
 
     // Use MemoryFile for React Native compatibility
     // React Native's File/Blob constructors don't properly support ArrayBuffer
-    return new MemoryFile(new Uint8Array(result.data), file.name, file.type) as unknown as File
+    const processedFile = new MemoryFile(new Uint8Array(result.data), file.name, result.mimeType) as unknown as File
+    return {
+      file: processedFile,
+      metadata: getFileMetadata(processedFile, { width: result.width, height: result.height })
+    }
   }
 }

--- a/packages/opfs/package.json
+++ b/packages/opfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/opfs",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "OPFS filesystem adapter for livestore-filesync",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/r2",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "Cloudflare R2 storage adapter for livestore-filesync with Worker utilities",

--- a/packages/s3-signer/package.json
+++ b/packages/s3-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livestore-filesync/s3-signer",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "S3-compatible signing service for livestore-filesync (Cloudflare Workers)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@livestore-filesync/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@livestore-filesync/image':
+        specifier: workspace:*
+        version: link:../../packages/image
       '@livestore-filesync/opfs':
         specifier: workspace:*
         version: link:../../packages/opfs
@@ -369,7 +372,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.19.0
-        version: 1.22.1(vite@7.3.1(@types/node@25.0.3)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260128.0)(wrangler@4.61.1(@cloudflare/workers-types@4.20260129.0))
+        version: 1.22.1(vite@7.3.1(@types/node@25.0.3)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260415.1)(wrangler@4.61.1(@cloudflare/workers-types@4.20260129.0))
       '@cloudflare/workers-types':
         specifier: ^4.20251118.0
         version: 4.20260129.0
@@ -439,7 +442,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.19.0
-        version: 1.22.1(vite@7.3.1(@types/node@25.0.3)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260415.1)(wrangler@4.61.1(@cloudflare/workers-types@4.20260129.0))
+        version: 1.22.1(vite@7.3.1(@types/node@25.0.3)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260128.0)(wrangler@4.61.1(@cloudflare/workers-types@4.20260129.0))
       '@cloudflare/workers-types':
         specifier: ^4.20251118.0
         version: 4.20260129.0

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-tests",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "private": true,
   "description": "Framework-agnostic E2E tests for livestore-filesync",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "Framework-agnostic E2E tests for livestore-filesync",
   "scripts": {
-    "test": "E2E_FRAMEWORK=react playwright test --project=chromium",
+    "test": "pnpm --filter @livestore-filesync/core build && E2E_FRAMEWORK=react playwright test --project=chromium",
     "test:vue": "E2E_FRAMEWORK=vue playwright test --project=chromium",
     "test:react": "E2E_FRAMEWORK=react playwright test --project=chromium",
     "test:ui": "playwright test --ui",

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -34,6 +34,11 @@ if (!config) {
   throw new Error(`Unknown framework: ${framework}. Use 'vue', 'react', 'thumbnail', 'vue-thumbnail', or 'react-thumbnail'.`)
 }
 
+const port = process.env.E2E_PORT ? Number(process.env.E2E_PORT) : config.port
+if (!Number.isInteger(port) || port <= 0) {
+  throw new Error(`Invalid E2E_PORT: ${process.env.E2E_PORT}`)
+}
+
 export default defineConfig({
   testDir: './tests',
   testMatch: config.testMatch,
@@ -46,7 +51,7 @@ export default defineConfig({
   reporter: 'html',
 
   use: {
-    baseURL: `http://localhost:${config.port}`,
+    baseURL: `http://localhost:${port}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -66,8 +71,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm run dev',
-    url: `http://localhost:${config.port}`,
+    command: `PORT=${port} pnpm run dev`,
+    url: `http://localhost:${port}`,
     reuseExistingServer: process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === 'true',
     cwd: config.cwd,
     timeout: 120000,

--- a/tests/e2e/tests/file-sync.spec.ts
+++ b/tests/e2e/tests/file-sync.spec.ts
@@ -67,6 +67,40 @@ test.describe('File Sync', () => {
     await waitForImageLoaded(page.locator('[data-testid="file-image"]'), 10000)
   })
 
+  test('should save and display files in local-only mode without remote requests', async ({ page }) => {
+    const remoteRequests: string[] = []
+    page.on('request', (request) => {
+      const url = new URL(request.url())
+      if (url.pathname.startsWith('/api') || url.pathname.startsWith('/livestore-filesync-files/')) {
+        remoteRequests.push(url.toString())
+      }
+    })
+
+    const storeId = generateStoreId('local_only')
+    await page.goto(`/?storeId=${storeId}&localOnly=1`)
+    await waitForLiveStoreAndSync(page)
+
+    await expect(page.locator('[data-testid="empty-state"]')).toBeVisible()
+
+    const testImage = createTestImage('blue')
+    await page.locator('input[type="file"]').setInputFiles(testImage)
+
+    await expect(page.locator('[data-testid="file-card"]')).toHaveCount(1, {
+      timeout: 10000,
+    })
+    await expect(page.locator('[data-testid="file-metadata"]')).toHaveText('400x400')
+    await waitForImageLoaded(page.locator('[data-testid="file-image"]'), 10000)
+
+    await expect(page.locator('[data-testid="file-remote-key"]')).toHaveText('')
+    await expect(page.locator('[data-testid="file-upload-status"]')).toHaveText('done')
+    await expect(page.locator('[data-testid="file-download-status"]')).toHaveText('done')
+    await expect(page.locator('[data-testid="sync-has-pending"]')).toHaveText('No')
+    await expect(page.locator('[data-testid="sync-error-count"]')).toHaveText('0')
+
+    await page.waitForTimeout(500)
+    expect(remoteRequests).toEqual([])
+  })
+
   test('should delete files from remote storage', async ({ page }) => {
     const storeId = generateStoreId()
     await page.goto(`/?storeId=${storeId}`)

--- a/tests/e2e/tests/file-sync.spec.ts
+++ b/tests/e2e/tests/file-sync.spec.ts
@@ -15,6 +15,33 @@ import {
   setOnline,
 } from './helpers'
 
+const formatPageError = (error: Error): string => {
+  const details = [
+    error.stack,
+    error.message && error.message !== error.stack ? `message=${error.message}` : undefined,
+    Object.getOwnPropertyNames(error)
+      .map((key) => {
+        const value = (error as unknown as Record<string, unknown>)[key]
+        return `${key}=${JSON.stringify(value)}`
+      })
+      .join(', '),
+  ].filter(Boolean)
+
+  return details.length > 0 ? details.join(' | ') : String(error)
+}
+
+const trackUnhandledRejections = async (page: { addInitScript: (script: () => void) => Promise<void> }): Promise<void> => {
+  await page.addInitScript(() => {
+    window.addEventListener('unhandledrejection', (event) => {
+      const reason = event.reason as unknown
+      const details = reason instanceof Error
+        ? (reason.stack || reason.message)
+        : JSON.stringify(reason)
+      console.error(`UNHANDLED_REJECTION ${details}`)
+    })
+  })
+}
+
 // React example has a known flakiness issue with multi-tab tests due to
 // LiveStore's new StoreProvider format having timing issues with SharedWorker
 // context sharing. Skip these tests for React until the upstream issue is resolved.
@@ -36,6 +63,7 @@ test.describe('File Sync', () => {
     await expect(page.locator('[data-testid="file-card"]')).toHaveCount(1, {
       timeout: 10000,
     })
+    await expect(page.locator('[data-testid="file-metadata"]')).toHaveText('400x400')
     await waitForImageLoaded(page.locator('[data-testid="file-image"]'), 10000)
   })
 
@@ -494,7 +522,7 @@ test.describe('File Sync', () => {
 
     const trackErrors = (page: typeof page1, label: string) => {
       page.on('pageerror', (error) => {
-        errors.push(`[${label}] ${error.message}`)
+        errors.push(`[${label}] ${formatPageError(error)}`)
       })
       page.on('console', (msg) => {
         const text = msg.text()
@@ -502,6 +530,7 @@ test.describe('File Sync', () => {
           text.includes('UNIQUE constraint') ||
           text.includes('UnknownError') ||
           text.includes('SqliteError') ||
+          text.includes('UNHANDLED_REJECTION') ||
           text.includes('ERROR')
         ) {
           consoleMessages.push(`[${label}] ${text}`)
@@ -591,7 +620,7 @@ test.describe('File Sync', () => {
 
     const trackErrors = (page: typeof page1, label: string) => {
       page.on('pageerror', (error) => {
-        errors.push(`[${label}] ${error.message}`)
+        errors.push(`[${label}] ${formatPageError(error)}`)
       })
       page.on('console', (msg) => {
         const text = msg.text()
@@ -599,6 +628,7 @@ test.describe('File Sync', () => {
           text.includes('UNIQUE constraint') ||
           text.includes('UnknownError') ||
           text.includes('SqliteError') ||
+          text.includes('UNHANDLED_REJECTION') ||
           text.includes('ERROR')
         ) {
           consoleMessages.push(`[${label}] ${text}`)
@@ -706,7 +736,7 @@ test.describe('File Sync', () => {
 
     const trackErrors = (page: typeof browser1TabA, label: string) => {
       page.on('pageerror', (error) => {
-        errors.push(`[${label}] ${error.message}`)
+        errors.push(`[${label}] ${formatPageError(error)}`)
       })
       page.on('console', (msg) => {
         const text = msg.text()
@@ -714,6 +744,7 @@ test.describe('File Sync', () => {
           text.includes('UNIQUE constraint') ||
           text.includes('UnknownError') ||
           text.includes('SqliteError') ||
+          text.includes('UNHANDLED_REJECTION') ||
           text.includes('ERROR')
         ) {
           consoleMessages.push(`[${label}] ${text}`)
@@ -721,6 +752,7 @@ test.describe('File Sync', () => {
       })
     }
 
+    await Promise.all(allTabs.map((tab) => trackUnhandledRejections(tab)))
     allTabs.forEach((tab, i) => trackErrors(tab, tabNames[i]))
 
     // Navigate tabs sequentially and wait for each to complete initial sync
@@ -1227,7 +1259,7 @@ test.describe('File Sync - Offline/Online Recovery', () => {
     const consoleMessages: string[] = []
 
     page.on('pageerror', (error) => {
-      errors.push(error.message)
+      errors.push(formatPageError(error))
     })
     page.on('console', (msg) => {
       const text = msg.text()

--- a/tests/e2e/tests/page-refresh-recovery.spec.ts
+++ b/tests/e2e/tests/page-refresh-recovery.spec.ts
@@ -569,13 +569,11 @@ test.describe('Page Refresh Recovery', () => {
       })
       .not.toBe(initialSrc)
 
-    // Wait for edit upload to start
+    // Wait for the delayed edit upload request to actually start before refreshing.
+    await expect.poll(() => editUploadStarted, { timeout: 15000 }).toBe(true)
     await expect(page.locator('[data-testid="file-upload-status"]')).toHaveText('inProgress', {
       timeout: 5000,
     })
-
-    // Ensure the upload request was actually intercepted
-    await expect.poll(() => editUploadStarted, { timeout: 5000 }).toBe(true)
 
     console.log('Edit upload in progress (with 5s delay), refreshing page...')
 


### PR DESCRIPTION
## Summary
- add explicit `remote: false` local-only mode for `initFileSync` and `createFileSync`
- keep local-only files available locally without signer calls, remote transfer queues, or upload errors
- add unit/e2e coverage and docs for unauthenticated guest/local-first apps

## Tests
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm --filter e2e-tests test`